### PR TITLE
feat(providers): add Yandex Cloud connector, fix(analytics): count charges as spend for providers without top-ups

### DIFF
--- a/apps/backend/nest-cli.json
+++ b/apps/backend/nest-cli.json
@@ -3,6 +3,8 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true
+    "deleteOutDir": true,
+    "assets": [{ "include": "**/*.proto", "outDir": "dist" }],
+    "watchAssets": true
   }
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -19,6 +19,8 @@
     "prisma:studio": "prisma studio"
   },
   "dependencies": {
+    "@grpc/grpc-js": "^1.14.4",
+    "@grpc/proto-loader": "^0.8.1",
     "@infra/shared": "*",
     "@nestjs/common": "^11.1.27",
     "@nestjs/core": "^11.1.27",

--- a/apps/backend/src/analytics/analytics.service.ts
+++ b/apps/backend/src/analytics/analytics.service.ts
@@ -71,10 +71,14 @@ export class AnalyticsService {
     let currentMonthPayments = ZERO();
     let totalSpent = ZERO();
     const spentByProvider = new Map<string, Decimal>();
+    // Providers that expose top-ups (BILLmanager, Timeweb…): their spend is the top-ups, and their
+    // `charge` rows are just per-service detail. Consumption-only providers (Yandex, Selectel) have
+    // no top-ups, so their charges ARE the spend and can be counted without double-counting.
+    const providersWithTopups = new Set(
+      payments.filter((p) => p.type !== 'charge').map((p) => p.providerUuid),
+    );
     for (const p of payments) {
-      // `charge` rows are per-service expense detail; counting them alongside top-ups would
-      // double the spend, so the paid-out totals use top-ups + manual payments only.
-      if (p.type === 'charge') continue;
+      if (p.type === 'charge' && providersWithTopups.has(p.providerUuid)) continue;
       const base = this.currency.convert(
         new Decimal(p.amount.toString()),
         p.currency,
@@ -377,10 +381,16 @@ export class AnalyticsService {
       projBuckets.set(key, ZERO());
     }
 
-    // Actuals: top-ups + manual payments (real money paid out), same definition as
-    // currentMonthPayments/totalSpent in summary() — keeps "Actual" consistent with the KPI card.
-    const payments = await this.paymentsRepo.listNonChargesSince(windowStart.toDate());
+    // Actuals: top-ups + manual payments, plus charges for consumption-only providers (no top-ups).
+    // Same definition as currentMonthPayments/totalSpent in summary() — keeps "Actual" consistent
+    // with the KPI card.
+    const [payments, topupProviderUuids] = await Promise.all([
+      this.paymentsRepo.listSince(windowStart.toDate()),
+      this.paymentsRepo.providerUuidsWithTopups(),
+    ]);
+    const providersWithTopups = new Set(topupProviderUuids);
     for (const p of payments) {
+      if (p.type === 'charge' && providersWithTopups.has(p.providerUuid)) continue;
       const key = dayjs(p.paymentDate).format('YYYY-MM');
       if (!actualBuckets.has(key) || key > currentKey) continue; // future-dated payments ignored
       const base = this.currency.convert(

--- a/apps/backend/src/connectors/connector.factory.ts
+++ b/apps/backend/src/connectors/connector.factory.ts
@@ -24,6 +24,8 @@ import { TimewebConnector } from './timeweb/timeweb.connector';
 import { VdsinaConnector } from './vdsina/vdsina.connector';
 import type { VdsinaCredentials } from './vdsina/vdsina.types';
 import { VultrConnector } from './vultr/vultr.connector';
+import { YandexConnector } from './yandex/yandex.connector';
+import type { YandexCredentials } from './yandex/yandex.types';
 
 @Injectable()
 export class ConnectorFactory {
@@ -79,6 +81,10 @@ export class ConnectorFactory {
       case 'stormwall':
         // StormWall secret is the raw API key (single string, sent as the x-api-key header).
         return new StormwallConnector(token);
+      case 'yandex':
+        // Yandex Cloud secret is JSON: { keyId, serviceAccountId, privateKey, folderId?,
+        // billingAccountId? }, normalized from the service-account authorized key.
+        return new YandexConnector(JSON.parse(token) as YandexCredentials);
       default:
         throw new Error(`Connector for kind="${kind}" is not supported`);
     }

--- a/apps/backend/src/connectors/yandex/proto/consumption.proto
+++ b/apps/backend/src/connectors/yandex/proto/consumption.proto
@@ -1,0 +1,85 @@
+syntax = "proto3";
+
+// Trimmed, self-contained slice of Yandex Cloud's Billing Usage API
+// (yandex.cloud.billing.usage_records.v1). Only the fields the connector reads are kept, but
+// field numbers match the upstream protos so the wire format stays compatible. The upstream
+// service is gRPC-only (no REST), which is why we ship a proto instead of using axios.
+// Upstream: github.com/yandex-cloud/cloudapi/tree/master/yandex/cloud/billing/usage_records/v1
+package yandex.cloud.billing.usage_records.v1;
+
+import "google/protobuf/timestamp.proto";
+
+// Decimal values are carried as strings to avoid float precision loss.
+message StringDecimal {
+  string value = 1;
+}
+
+enum TimeGrouping {
+  TIME_GROUPING_UNSPECIFIED = 0;
+  DAY = 1;
+  WEEK = 2;
+  MONTH = 3;
+  QUARTER = 4;
+  YEAR = 5;
+}
+
+enum Currency {
+  CURRENCY_UNSPECIFIED = 0;
+  RUB = 1;
+  USD = 2;
+  KZT = 3;
+  EUR = 4;
+}
+
+message CreditDetails {
+  StringDecimal credit = 1;
+  StringDecimal monetary_grant_credit = 2;
+  StringDecimal volume_incentive_credit = 3;
+  StringDecimal cud_credit = 4;
+  StringDecimal free_credit = 5;
+}
+
+message BillingAccount {
+  string id = 1;
+  string name = 2;
+}
+
+message UsageReportRequest {
+  string billing_account_id = 1;
+  google.protobuf.Timestamp start_date = 2;
+  google.protobuf.Timestamp end_date = 3;
+  repeated string cloud_ids = 4;
+  repeated string folder_ids = 5;
+  repeated string service_ids = 6;
+  repeated string sku_ids = 7;
+  repeated string resource_ids = 9;
+  TimeGrouping aggregation_period = 10;
+}
+
+// One aggregation period (a single day when aggregation_period = DAY).
+message UsageReportPeriodicData {
+  StringDecimal cost = 1;
+  CreditDetails credit_details = 2;
+  StringDecimal expense = 3;
+  google.protobuf.Timestamp timestamp = 4;
+}
+
+message BillingAccountUsageReportEntityData {
+  StringDecimal cost = 1;
+  CreditDetails credit_details = 2;
+  StringDecimal expense = 3;
+  BillingAccount billing_account = 4;
+  repeated UsageReportPeriodicData periodic = 5;
+}
+
+message BillingAccountUsageReportResponse {
+  Currency currency = 1;
+  StringDecimal cost = 2;
+  CreditDetails credit_details = 3;
+  StringDecimal expense = 4;
+  repeated BillingAccountUsageReportEntityData entities_data = 5;
+}
+
+service ConsumptionCoreService {
+  rpc GetBillingAccountUsageReport(UsageReportRequest) returns (BillingAccountUsageReportResponse);
+}

--- a/apps/backend/src/connectors/yandex/yandex.connector.ts
+++ b/apps/backend/src/connectors/yandex/yandex.connector.ts
@@ -1,0 +1,281 @@
+import axios, { type AxiosInstance } from 'axios';
+import Decimal from 'decimal.js';
+import jwt from 'jsonwebtoken';
+import { REQUEST_TIMEOUT_MS } from '../common/http';
+import { Account, Connector, PaymentData, ServiceData } from '../connector.interface';
+import { fetchResourceExpense, fetchUsageReport } from './yandex.consumption';
+import { aggregateUsageByDay, mapYandexInstance } from './yandex.mapper';
+import {
+  BillingAccountsResponse,
+  IamTokenResponse,
+  YandexBillingAccount,
+  YandexCredentials,
+  YandexInstance,
+} from './yandex.types';
+
+const IAM_URL = 'https://iam.api.cloud.yandex.net/iam/v1/tokens';
+const IAM_SA_URL = 'https://iam.api.cloud.yandex.net/iam/v1/serviceAccounts';
+const BILLING_URL = 'https://billing.api.cloud.yandex.net/billing/v1';
+const RESOURCE_MANAGER_URL = 'https://resource-manager.api.cloud.yandex.net/resource-manager/v1';
+const COMPUTE_URL = 'https://compute.api.cloud.yandex.net/compute/v1';
+
+const PAGE_SIZE = 1000; // Yandex Cloud list APIs cap page_size at 1000
+const MAX_PAGES = 50; // safety cap against a misbehaving pagination contract
+// Authorized-key JWTs may live at most one hour; refresh the IAM token a little early.
+const TOKEN_TTL_MS = 55 * 60 * 1000;
+// How many months of consumption history to import on each sync.
+const CONSUMPTION_MONTHS = 3;
+
+/**
+ * Yandex Cloud connector. Auth: a service-account authorized key (JSON) is signed into a JWT
+ * (PS256) and exchanged for a short-lived IAM token, sent as `Authorization: Bearer`. Balance +
+ * currency come from the Billing API (`/billingAccounts`, first active); servers from the Compute
+ * API (`/instances`), scanning the service account's own folder (resolved from its
+ * `service_account_id` via IAM), which is the folder the key already grants access to. Compute is
+ * usage-billed with no per-instance price in the Compute API, so each server's "monthly cost" is
+ * last full month's actual consumption pulled per resource from the Billing Usage API. No
+ * maintained npm SDK → thin axios client, like the other connectors. Consumption history comes from
+ * the Billing Usage API, which is gRPC-only — see ./yandex.consumption.ts.
+ */
+export class YandexConnector implements Connector {
+  private readonly http: AxiosInstance;
+  private readonly creds: YandexCredentials;
+  private token: { value: string; expiresAt: number } | null = null;
+
+  constructor(creds: YandexCredentials) {
+    this.creds = creds;
+    this.http = axios.create({ timeout: REQUEST_TIMEOUT_MS });
+    // Surface Yandex Cloud's structured error ({ code, message }) instead of a bare HTTP status.
+    this.http.interceptors.response.use(undefined, (e) => {
+      if (axios.isAxiosError(e)) {
+        const body = e.response?.data as { message?: string } | undefined;
+        if (body?.message) throw new Error(`Yandex Cloud: ${body.message}`);
+      }
+      throw e;
+    });
+  }
+
+  kind(): string {
+    return 'yandex';
+  }
+
+  async fetchAccount(signal: AbortSignal): Promise<Account> {
+    const account = await this.resolveBillingAccount(signal);
+    if (!account) return { balance: null, currency: 'RUB' };
+    return {
+      balance: new Decimal(account.balance || '0'),
+      currency: (account.currency || 'RUB').toUpperCase(),
+    };
+  }
+
+  async fetchServices(signal: AbortSignal): Promise<ServiceData[]> {
+    const folderIds = await this.resolveFolderIds(signal);
+    const perFolder = await Promise.allSettled(
+      folderIds.map((folderId) =>
+        this.paginate<YandexInstance>(
+          `${COMPUTE_URL}/instances`,
+          'instances',
+          { folderId },
+          signal,
+        ),
+      ),
+    );
+    const services = perFolder
+      .flatMap((r) => (r.status === 'fulfilled' ? r.value : []))
+      .map(mapYandexInstance);
+    await this.attachMonthlyCost(services, signal);
+    return services;
+  }
+
+  /**
+   * Fill in each server's monthly cost and next-billing date. Compute is usage-billed, so the
+   * "monthly cost" is last full month's actual billable consumption of that instance, pulled from
+   * the Billing Usage API per resource; the next-billing date is the start of the next month (when
+   * Yandex closes the current billing period), the same for every server. Best-effort: a missing
+   * billing role or a report error leaves cost unset without failing the sync.
+   */
+  private async attachMonthlyCost(services: ServiceData[], signal: AbortSignal): Promise<void> {
+    if (services.length === 0) return;
+    const nextBilling = firstOfNextMonthUtc();
+    for (const s of services) s.nextBilling = nextBilling;
+    const account = await this.resolveBillingAccount(signal);
+    if (!account) return;
+    const token = await this.iamToken(signal);
+    const { start, end } = previousFullMonthUtc();
+    const currency = (account.currency || 'RUB').toUpperCase();
+    for (const s of services) {
+      if (signal.aborted) return;
+      try {
+        const expense = await fetchResourceExpense(
+          account.id,
+          token,
+          start,
+          end,
+          s.externalId,
+          signal,
+        );
+        if (expense != null) {
+          s.cost = new Decimal(expense);
+          s.currency = currency;
+          s.period = 'monthly';
+        }
+      } catch {
+        // Best-effort: leave this server's cost unset and keep the sync going.
+      }
+    }
+  }
+
+  /**
+   * Import consumption as one `charge` per day from the Billing Usage API (gRPC). Account-wide, to
+   * match the balance; needs the `billing.accounts.getReport` permission. Returns nothing when no
+   * billing account resolves (missing role / no account); a permission or rate-limit error is
+   * thrown with guidance and left non-fatal by the sync.
+   */
+  async fetchPayments(signal: AbortSignal): Promise<PaymentData[]> {
+    const account = await this.resolveBillingAccount(signal);
+    if (!account) return [];
+    const token = await this.iamToken(signal);
+    const now = new Date();
+    const start = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - CONSUMPTION_MONTHS, 1),
+    );
+    const { currency, periodic } = await fetchUsageReport(account.id, token, start, now, signal);
+    return aggregateUsageByDay(periodic, (currency || account.currency || 'RUB').toUpperCase());
+  }
+
+  /**
+   * The scope the connector will actually use: the folders scanned for servers and the billing
+   * account used for balance / consumption. Powers the provider form's read-only badges. Auth
+   * errors on the key surface to the caller; a missing billing role degrades to a null account.
+   */
+  async discover(signal: AbortSignal): Promise<{
+    folders: { id: string; name: string }[];
+    billingAccount: { id: string; name: string } | null;
+  }> {
+    const [folders, account] = await Promise.all([
+      this.resolveFolders(signal),
+      this.resolveBillingAccount(signal),
+    ]);
+    return {
+      folders,
+      billingAccount: account ? { id: account.id, name: account.name || account.id } : null,
+    };
+  }
+
+  /**
+   * The folder to scan for servers: the service account's own folder, resolved from its
+   * `service_account_id` via IAM. There is no account-wide instance list (Compute lists per
+   * folder), and enumerating clouds needs cloud-level rights a scoped key doesn't have, so we use
+   * the home folder — the one the key already grants access to.
+   */
+  private async resolveFolders(signal: AbortSignal): Promise<{ id: string; name: string }[]> {
+    const home = await this.homeFolder(signal);
+    return home ? [home] : [];
+  }
+
+  /** The service account's own folder (id + name), read from IAM by its `service_account_id`. */
+  private async homeFolder(signal: AbortSignal): Promise<{ id: string; name: string } | null> {
+    const headers = await this.authHeaders(signal);
+    const sa = await this.http.get<{ folderId?: string }>(
+      `${IAM_SA_URL}/${this.creds.serviceAccountId}`,
+      { headers, signal, validateStatus: (s) => s === 200 || s === 403 || s === 404 },
+    );
+    const folderId = sa.status === 200 ? sa.data.folderId : undefined;
+    if (!folderId) return null;
+    const folder = await this.http.get<{ name?: string }>(
+      `${RESOURCE_MANAGER_URL}/folders/${folderId}`,
+      { headers, signal, validateStatus: (s) => s === 200 || s === 403 || s === 404 },
+    );
+    return { id: folderId, name: (folder.status === 200 && folder.data.name) || folderId };
+  }
+
+  /**
+   * The first active billing account (falls back to the first of any). Balance is secondary to the
+   * server inventory, so a missing billing role (403) degrades to "no balance" (null) rather than
+   * failing the whole sync.
+   */
+  private async resolveBillingAccount(signal: AbortSignal): Promise<YandexBillingAccount | null> {
+    const headers = await this.authHeaders(signal);
+    const res = await this.http.get<BillingAccountsResponse>(`${BILLING_URL}/billingAccounts`, {
+      headers,
+      signal,
+      validateStatus: (s) => s === 200 || s === 403,
+    });
+    const accounts = res.status === 200 ? (res.data.billingAccounts ?? []) : [];
+    return accounts.find((a) => a.active) ?? accounts[0] ?? null;
+  }
+
+  /** Folder ids to scan for servers (the same set surfaced as badges by `discover`). */
+  private async resolveFolderIds(signal: AbortSignal): Promise<string[]> {
+    return (await this.resolveFolders(signal)).map((f) => f.id);
+  }
+
+  /** Cached IAM token, minted from a freshly signed JWT when missing or near expiry. */
+  private async iamToken(signal: AbortSignal): Promise<string> {
+    if (!this.token || Date.now() >= this.token.expiresAt) {
+      this.token = { value: await this.mintIamToken(signal), expiresAt: Date.now() + TOKEN_TTL_MS };
+    }
+    return this.token.value;
+  }
+
+  private async authHeaders(signal: AbortSignal): Promise<Record<string, string>> {
+    return { Authorization: `Bearer ${await this.iamToken(signal)}` };
+  }
+
+  /** Sign a PS256 JWT with the authorized key and exchange it for an IAM token. */
+  private async mintIamToken(signal: AbortSignal): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    let assertion: string;
+    try {
+      assertion = jwt.sign(
+        { iss: this.creds.serviceAccountId, aud: IAM_URL, iat: now, exp: now + 3600 },
+        this.creds.privateKey,
+        { algorithm: 'PS256', keyid: this.creds.keyId },
+      );
+    } catch {
+      throw new Error('Yandex Cloud: invalid authorized key (could not sign the JWT)');
+    }
+    const { data } = await this.http.post<IamTokenResponse>(
+      IAM_URL,
+      { jwt: assertion },
+      { signal },
+    );
+    if (!data.iamToken) throw new Error('Yandex Cloud: IAM token was not issued');
+    return data.iamToken;
+  }
+
+  /** Walk a Yandex Cloud list endpoint's pageToken/nextPageToken pagination, accumulating `key`. */
+  private async paginate<T>(
+    url: string,
+    key: string,
+    params: Record<string, string>,
+    signal: AbortSignal,
+  ): Promise<T[]> {
+    const headers = await this.authHeaders(signal);
+    const out: T[] = [];
+    let pageToken: string | undefined;
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const { data } = await this.http.get<Record<string, unknown>>(url, {
+        headers,
+        params: { ...params, pageSize: PAGE_SIZE, pageToken },
+        signal,
+      });
+      out.push(...((data[key] as T[]) ?? []));
+      pageToken = data.nextPageToken as string | undefined;
+      if (!pageToken) break;
+    }
+    return out;
+  }
+}
+
+/** [start, end) of the previous calendar month in UTC, for the per-server consumption report. */
+function previousFullMonthUtc(now = new Date()): { start: Date; end: Date } {
+  const y = now.getUTCFullYear();
+  const m = now.getUTCMonth();
+  return { start: new Date(Date.UTC(y, m - 1, 1)), end: new Date(Date.UTC(y, m, 1)) };
+}
+
+/** Start of next month in UTC: when Yandex closes the current billing period. */
+function firstOfNextMonthUtc(now = new Date()): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1));
+}

--- a/apps/backend/src/connectors/yandex/yandex.consumption.ts
+++ b/apps/backend/src/connectors/yandex/yandex.consumption.ts
@@ -1,0 +1,152 @@
+import path from 'node:path';
+import * as grpc from '@grpc/grpc-js';
+import * as protoLoader from '@grpc/proto-loader';
+import { UsageReportPeriodicData, UsageReportResponse } from './yandex.types';
+
+// The Billing Usage API is gRPC-only (no REST counterpart), so this module wraps a thin gRPC
+// client around a trimmed proto (see ./proto/consumption.proto). It is kept apart from the axios
+// connector so the gRPC dependency stays contained to the one call that needs it.
+const BILLING_GRPC_ENDPOINT = 'billing.api.cloud.yandex.net:443';
+const PROTO_PATH = path.join(__dirname, 'proto', 'consumption.proto');
+// The report is served at most once per minute per IP; keep a generous deadline.
+const CALL_DEADLINE_MS = 60_000;
+
+interface UsageReportRequestMessage {
+  billingAccountId: string;
+  startDate: { seconds: number; nanos: number };
+  endDate: { seconds: number; nanos: number };
+  resourceIds?: string[];
+  aggregationPeriod: string;
+}
+
+interface ConsumptionClient extends grpc.Client {
+  GetBillingAccountUsageReport(
+    req: UsageReportRequestMessage,
+    metadata: grpc.Metadata,
+    options: grpc.CallOptions,
+    callback: (err: grpc.ServiceError | null, resp: UsageReportResponse) => void,
+  ): grpc.ClientUnaryCall;
+}
+
+type ConsumptionClientCtor = new (
+  address: string,
+  credentials: grpc.ChannelCredentials,
+) => ConsumptionClient;
+
+let cachedCtor: ConsumptionClientCtor | null = null;
+
+function consumptionClientCtor(): ConsumptionClientCtor {
+  if (cachedCtor) return cachedCtor;
+  const def = protoLoader.loadSync(PROTO_PATH, {
+    keepCase: false,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true,
+  });
+  const pkg = grpc.loadPackageDefinition(def) as unknown as {
+    yandex: {
+      cloud: {
+        billing: {
+          usage_records: { v1: { ConsumptionCoreService: ConsumptionClientCtor } };
+        };
+      };
+    };
+  };
+  cachedCtor = pkg.yandex.cloud.billing.usage_records.v1.ConsumptionCoreService;
+  return cachedCtor;
+}
+
+/** gRPC status codes we translate into actionable messages; the rest surface verbatim. */
+function reportError(err: grpc.ServiceError): Error {
+  if (err.code === grpc.status.PERMISSION_DENIED) {
+    return new Error(
+      'Yandex Cloud: no permission to read consumption. Assign the service account the ' +
+        'billing.accounts.getReport permission (role billing.accounts.viewer or higher) on the billing account.',
+    );
+  }
+  if (err.code === grpc.status.RESOURCE_EXHAUSTED) {
+    return new Error(
+      'Yandex Cloud: consumption report rate limit reached (1 request/minute) — try later',
+    );
+  }
+  return new Error(`Yandex Cloud: consumption report failed — ${err.details || err.message}`);
+}
+
+/**
+ * Pull the billing account's daily consumption for [start, end] via the gRPC Billing Usage API.
+ * Returns the per-day time series (one point per calendar day); the caller maps it to charges.
+ */
+export async function fetchUsageReport(
+  billingAccountId: string,
+  iamToken: string,
+  start: Date,
+  end: Date,
+  signal: AbortSignal,
+): Promise<{ currency?: string; periodic: UsageReportPeriodicData[] }> {
+  const Ctor = consumptionClientCtor();
+  const client = new Ctor(BILLING_GRPC_ENDPOINT, grpc.credentials.createSsl());
+  const metadata = new grpc.Metadata();
+  metadata.set('authorization', `Bearer ${iamToken}`);
+
+  try {
+    const resp = await new Promise<UsageReportResponse>((resolve, reject) => {
+      const call = client.GetBillingAccountUsageReport(
+        {
+          billingAccountId,
+          startDate: { seconds: Math.floor(start.getTime() / 1000), nanos: 0 },
+          endDate: { seconds: Math.floor(end.getTime() / 1000), nanos: 0 },
+          aggregationPeriod: 'DAY',
+        },
+        metadata,
+        { deadline: Date.now() + CALL_DEADLINE_MS },
+        (err, value) => (err ? reject(reportError(err)) : resolve(value)),
+      );
+      // Abort the in-flight call if the surrounding sync is cancelled.
+      signal.addEventListener('abort', () => call.cancel(), { once: true });
+    });
+    return { currency: resp.currency, periodic: resp.entitiesData?.[0]?.periodic ?? [] };
+  } finally {
+    client.close();
+  }
+}
+
+/**
+ * Total billable consumption of a single resource over [start, end], via the same gRPC report
+ * filtered by `resource_ids`. The report has no per-resource grouping, so we scope each call to one
+ * resource and read the account entity's period `expense`. Used to attach a per-server monthly cost.
+ */
+export async function fetchResourceExpense(
+  billingAccountId: string,
+  iamToken: string,
+  start: Date,
+  end: Date,
+  resourceId: string,
+  signal: AbortSignal,
+): Promise<string | null> {
+  const Ctor = consumptionClientCtor();
+  const client = new Ctor(BILLING_GRPC_ENDPOINT, grpc.credentials.createSsl());
+  const metadata = new grpc.Metadata();
+  metadata.set('authorization', `Bearer ${iamToken}`);
+
+  try {
+    const resp = await new Promise<UsageReportResponse>((resolve, reject) => {
+      const call = client.GetBillingAccountUsageReport(
+        {
+          billingAccountId,
+          startDate: { seconds: Math.floor(start.getTime() / 1000), nanos: 0 },
+          endDate: { seconds: Math.floor(end.getTime() / 1000), nanos: 0 },
+          resourceIds: [resourceId],
+          aggregationPeriod: 'MONTH',
+        },
+        metadata,
+        { deadline: Date.now() + CALL_DEADLINE_MS },
+        (err, value) => (err ? reject(reportError(err)) : resolve(value)),
+      );
+      signal.addEventListener('abort', () => call.cancel(), { once: true });
+    });
+    return resp.entitiesData?.[0]?.expense?.value ?? null;
+  } finally {
+    client.close();
+  }
+}

--- a/apps/backend/src/connectors/yandex/yandex.mapper.ts
+++ b/apps/backend/src/connectors/yandex/yandex.mapper.ts
@@ -1,0 +1,68 @@
+import Decimal from 'decimal.js';
+import { PaymentData, ServiceData } from '../connector.interface';
+import { UsageReportPeriodicData, YandexInstance } from './yandex.types';
+
+// Yandex Cloud zones map to a country by their region prefix. Compute is usage-billed, so cost is
+// filled in later by the connector from the per-resource Billing Usage report, not here.
+function countryForZone(zoneId?: string): string | undefined {
+  if (!zoneId) return undefined;
+  if (zoneId.startsWith('ru')) return 'RU';
+  if (zoneId.startsWith('kz')) return 'KZ';
+  return undefined;
+}
+
+// `memory` comes back as a byte count string; expose GiB for readability, leaving raw bytes too.
+function memoryGib(memory?: string): number | undefined {
+  if (!memory) return undefined;
+  const bytes = Number(memory);
+  if (!Number.isFinite(bytes) || bytes <= 0) return undefined;
+  return Math.round((bytes / 1024 ** 3) * 100) / 100;
+}
+
+export function mapYandexInstance(i: YandexInstance): ServiceData {
+  return {
+    externalId: i.id,
+    name: i.name || `yc-${i.id}`,
+    type: 'vps',
+    countryCode: countryForZone(i.zoneId),
+    period: 'monthly',
+    meta: {
+      folderId: i.folderId,
+      zoneId: i.zoneId,
+      platformId: i.platformId,
+      status: i.status,
+      cores: i.resources?.cores,
+      coreFraction: i.resources?.coreFraction,
+      memoryGib: memoryGib(i.resources?.memory),
+    },
+  };
+}
+
+/**
+ * Turn the Billing Usage API's daily time series into one `charge` per calendar day. We record
+ * `expense` (the final billable amount after grants/credits), i.e. the money that actually leaves
+ * the balance — days fully covered by a grant have expense 0 and are skipped. Idempotent across
+ * re-syncs via the per-day externalId.
+ */
+export function aggregateUsageByDay(
+  periodic: UsageReportPeriodicData[],
+  currency: string,
+): PaymentData[] {
+  const out: PaymentData[] = [];
+  for (const p of periodic) {
+    const seconds = Number(p.timestamp?.seconds ?? NaN);
+    if (!Number.isFinite(seconds)) continue;
+    const day = new Date(seconds * 1000).toISOString().slice(0, 10); // YYYY-MM-DD (UTC)
+    const amount = new Decimal(p.expense?.value || '0');
+    if (amount.lte(0)) continue;
+    out.push({
+      externalId: `yc:day:${day}`, // one charge per day; idempotent across re-syncs
+      type: 'charge',
+      amount,
+      currency,
+      date: new Date(`${day}T00:00:00Z`),
+      description: 'Yandex Cloud consumption',
+    });
+  }
+  return out;
+}

--- a/apps/backend/src/connectors/yandex/yandex.types.ts
+++ b/apps/backend/src/connectors/yandex/yandex.types.ts
@@ -1,0 +1,67 @@
+// Yandex Cloud API response shapes and stored credentials. Only consumed fields are typed.
+
+// Decrypted credentials, normalized from the service-account authorized-key JSON. Scope (folders,
+// billing account) is always auto-resolved by the connector, so it is not stored.
+export interface YandexCredentials {
+  keyId: string; // authorized key id → JWT `kid`
+  serviceAccountId: string; // → JWT `iss`
+  privateKey: string; // PEM private key, signs the JWT (PS256)
+}
+
+// The raw authorized-key file produced by Yandex Cloud (yc iam key create / API). Parsed on save.
+export interface YandexAuthorizedKey {
+  id?: string;
+  service_account_id?: string;
+  private_key?: string;
+}
+
+export interface IamTokenResponse {
+  iamToken: string;
+  expiresAt: string; // RFC3339
+}
+
+export interface YandexBillingAccount {
+  id: string;
+  name: string;
+  currency: string; // RUB / USD / KZT
+  active: boolean;
+  balance: string; // decimal string, positive = funds
+}
+
+export interface BillingAccountsResponse {
+  billingAccounts?: YandexBillingAccount[];
+  nextPageToken?: string;
+}
+
+export interface YandexInstance {
+  id: string;
+  folderId: string;
+  name?: string;
+  zoneId?: string; // e.g. "ru-central1-a" → country
+  platformId?: string;
+  status?: string;
+  resources?: { memory?: string; cores?: string; coreFraction?: string; gpus?: string };
+  [key: string]: unknown;
+}
+
+// Billing Usage API (gRPC) shapes. Decimals arrive as { value: "123.45" } strings; the report is
+// requested with DAY aggregation so `periodic` holds one point per calendar day.
+export interface StringDecimal {
+  value?: string;
+}
+
+export interface UsageReportPeriodicData {
+  cost?: StringDecimal; // gross consumption, before credits
+  expense?: StringDecimal; // final billable (cost minus credits) — the real money spent
+  timestamp?: { seconds?: string | number }; // start of the aggregation period
+}
+
+export interface UsageReportEntityData {
+  expense?: StringDecimal; // period total for the entity (final billable)
+  periodic?: UsageReportPeriodicData[];
+}
+
+export interface UsageReportResponse {
+  currency?: string; // enum name, e.g. "RUB"
+  entitiesData?: UsageReportEntityData[];
+}

--- a/apps/backend/src/providers/dto/provider.dto.ts
+++ b/apps/backend/src/providers/dto/provider.dto.ts
@@ -7,12 +7,16 @@ import {
   providerSchema,
   serviceSchema,
   updateProviderSchema,
+  yandexDiscoverResultSchema,
+  yandexDiscoverSchema,
 } from '@infra/shared';
 import { z } from 'zod';
 
 export class CreateProviderDto extends createZodDto(createProviderSchema) {}
 export class UpdateProviderDto extends createZodDto(updateProviderSchema) {}
 export class NetcupDevicePollDto extends createZodDto(netcupDevicePollSchema) {}
+export class YandexDiscoverDto extends createZodDto(yandexDiscoverSchema) {}
+export class YandexDiscoverResultDto extends createZodDto(yandexDiscoverResultSchema) {}
 
 export class ProviderDto extends createZodDto(providerSchema) {}
 export class ProviderWithServicesDto extends createZodDto(

--- a/apps/backend/src/providers/providers.controller.ts
+++ b/apps/backend/src/providers/providers.controller.ts
@@ -20,6 +20,8 @@ import {
   ProviderDto,
   ProviderWithServicesDto,
   UpdateProviderDto,
+  YandexDiscoverDto,
+  YandexDiscoverResultDto,
 } from './dto/provider.dto';
 import {
   ApiBearerAuth,
@@ -68,6 +70,15 @@ export class ProvidersController {
   @ApiOkResponse({ type: NetcupDevicePollResultDto })
   netcupDevicePoll(@Body() dto: NetcupDevicePollDto) {
     return this.netcupDevice.poll(dto.deviceCode);
+  }
+
+  // Yandex folder / billing-account discovery for the form dropdowns. Static path, before `:uuid`.
+  @Post(API_SUB.PROVIDER_YANDEX_DISCOVER)
+  @HttpCode(200)
+  @ApiOperation({ summary: 'Discover Yandex folders and billing accounts' })
+  @ApiOkResponse({ type: YandexDiscoverResultDto })
+  yandexDiscover(@Body() dto: YandexDiscoverDto) {
+    return this.providers.discoverYandex(dto);
   }
 
   @Get(API_SUB.BY_ID)

--- a/apps/backend/src/providers/providers.service.ts
+++ b/apps/backend/src/providers/providers.service.ts
@@ -1,11 +1,20 @@
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@generated/prisma/client';
-import { Provider as ProviderDto, Service as ServiceDto } from '@infra/shared';
+import {
+  Provider as ProviderDto,
+  Service as ServiceDto,
+  YandexDiscoverResult,
+} from '@infra/shared';
 import { ProvidersRepository } from '@repositories/providers/providers.repository';
 import { VDSINA_BASE_URLS } from '@connectors/vdsina/vdsina.types';
+import { YandexConnector } from '../connectors/yandex/yandex.connector';
+import type { YandexCredentials } from '../connectors/yandex/yandex.types';
 import { CryptoService } from '../crypto/crypto.service';
 import { mapProvider, mapService } from '@common/mappers';
-import { CreateProviderDto, UpdateProviderDto } from './dto/provider.dto';
+import { CreateProviderDto, UpdateProviderDto, YandexDiscoverDto } from './dto/provider.dto';
+
+// Cap the discovery call so a hanging Yandex API request can't wedge the request handler.
+const DISCOVER_TIMEOUT_MS = 20_000;
 
 @Injectable()
 export class ProvidersService {
@@ -217,8 +226,91 @@ export class ProvidersService {
       }
       return this.crypto.encrypt(JSON.stringify({ apiKey, secretApiKey }));
     }
+    if (kind === 'yandex') {
+      // `token` carries the service-account authorized key (JSON); parse it into { keyId,
+      // serviceAccountId, privateKey }. Scope (folders, billing account) is auto-resolved, never
+      // stored. Nothing to merge — an edit without a new key leaves the stored one intact.
+      if (!dto.token) return null;
+      const key = this.parseYandexKey(dto.token);
+      if (!key.keyId || !key.serviceAccountId || !key.privateKey) {
+        throw new BadRequestException(
+          'Provide the Yandex Cloud service account authorized key (JSON)',
+        );
+      }
+      return this.crypto.encrypt(JSON.stringify(key));
+    }
     if (kind !== 'manual' && dto.token) return this.crypto.encrypt(dto.token);
     return null;
+  }
+
+  /**
+   * Resolve the Yandex scope (folders scanned for servers + billing account) for the form badges,
+   * using either the just-entered authorized key (create flow) or the stored credentials of an
+   * existing provider (edit flow).
+   */
+  async discoverYandex(dto: YandexDiscoverDto): Promise<YandexDiscoverResult> {
+    const creds = await this.yandexCredsFor(dto);
+    const connector = new YandexConnector(creds);
+    try {
+      return await connector.discover(AbortSignal.timeout(DISCOVER_TIMEOUT_MS));
+    } catch (e) {
+      throw new BadRequestException(
+        e instanceof Error ? e.message : 'Yandex Cloud discovery failed',
+      );
+    }
+  }
+
+  /** Resolve the auth part of the Yandex credentials from a raw key or a stored provider. */
+  private async yandexCredsFor(dto: YandexDiscoverDto): Promise<YandexCredentials> {
+    if (dto.token) {
+      const key = this.parseYandexKey(dto.token);
+      if (!key.keyId || !key.serviceAccountId || !key.privateKey) {
+        throw new BadRequestException(
+          'Provide the Yandex Cloud service account authorized key (JSON)',
+        );
+      }
+      return {
+        keyId: key.keyId,
+        serviceAccountId: key.serviceAccountId,
+        privateKey: key.privateKey,
+      };
+    }
+    if (dto.providerUuid) {
+      const existing = await this.providers.findCredentials(dto.providerUuid);
+      if (existing?.kind !== 'yandex') {
+        throw new NotFoundException('Yandex provider not found');
+      }
+      const c = this.decodeCredentials(existing.credentialsEnc);
+      if (!c.keyId || !c.serviceAccountId || !c.privateKey) {
+        throw new BadRequestException('Stored Yandex credentials are incomplete');
+      }
+      return {
+        keyId: c.keyId,
+        serviceAccountId: c.serviceAccountId,
+        privateKey: c.privateKey,
+      };
+    }
+    throw new BadRequestException('Provide the authorized key or an existing provider');
+  }
+
+  /** Parse a Yandex Cloud authorized-key JSON into the fields we sign the JWT with. */
+  private parseYandexKey(raw: string): {
+    keyId?: string;
+    serviceAccountId?: string;
+    privateKey?: string;
+  } {
+    let obj: { id?: string; service_account_id?: string; private_key?: string };
+    try {
+      obj = JSON.parse(raw);
+    } catch {
+      throw new BadRequestException('Yandex Cloud authorized key must be the JSON key file');
+    }
+    if (!obj.id || !obj.service_account_id || !obj.private_key) {
+      throw new BadRequestException(
+        'Yandex Cloud authorized key is missing id, service_account_id or private_key',
+      );
+    }
+    return { keyId: obj.id, serviceAccountId: obj.service_account_id, privateKey: obj.private_key };
   }
 
   /** Decrypt the stored JSON credentials (hostbill/billmgr), or {} if none/unparseable. */

--- a/apps/backend/src/repositories/payments/payments.repository.ts
+++ b/apps/backend/src/repositories/payments/payments.repository.ts
@@ -27,11 +27,23 @@ export class PaymentsRepository {
     return this.prisma.payment.findMany();
   }
 
-  /** Top-ups + manual payments since `from` — real money paid out; `charge` rows excluded. */
-  listNonChargesSince(from: Date) {
-    return this.prisma.payment.findMany({
-      where: { type: { not: 'charge' }, paymentDate: { gte: from } },
+  /** All payments since `from` (any type); the caller decides which count as spend. */
+  listSince(from: Date) {
+    return this.prisma.payment.findMany({ where: { paymentDate: { gte: from } } });
+  }
+
+  /**
+   * Provider uuids that have at least one top-up / manual payment (type != `charge`). Used to tell
+   * consumption-only providers (Yandex, Selectel — charges but no top-ups) apart from providers
+   * where top-ups already represent the spend, so charges aren't double-counted.
+   */
+  async providerUuidsWithTopups(): Promise<string[]> {
+    const rows = await this.prisma.payment.findMany({
+      where: { type: { not: 'charge' } },
+      distinct: ['providerUuid'],
+      select: { providerUuid: true },
     });
+    return rows.map((r) => r.providerUuid);
   }
 
   async listPaginated(

--- a/apps/frontend/src/api/providers.ts
+++ b/apps/frontend/src/api/providers.ts
@@ -6,6 +6,8 @@ import type {
   Provider,
   SyncRun,
   UpdateProvider,
+  YandexDiscover,
+  YandexDiscoverResult,
 } from '@infra/shared';
 import { api } from './client';
 import { API_PATH } from '@infra/shared';
@@ -95,5 +97,22 @@ export function useNetcupDevicePoll() {
           deviceCode,
         })
       ).data,
+  });
+}
+
+/**
+ * Resolve the Yandex scope (folders + billing account) from a pasted key or an existing provider.
+ * A query (not a mutation) so the 200 result survives StrictMode's double mount and is cached per
+ * input - a mutate-scoped callback would be dropped on the throwaway first mount, leaving the form
+ * stuck on "Resolving". Pass `null` to stay idle (wrong kind / incomplete key).
+ */
+export function useYandexDiscover(body: YandexDiscover | null) {
+  return useQuery({
+    queryKey: ['yandex-discover', body],
+    enabled: body != null,
+    retry: false,
+    staleTime: Number.POSITIVE_INFINITY,
+    queryFn: async () =>
+      (await api.post<YandexDiscoverResult>(API_PATH.PROVIDERS.YANDEX_DISCOVER, body)).data,
   });
 }

--- a/apps/frontend/src/components/ProviderIcon.tsx
+++ b/apps/frontend/src/components/ProviderIcon.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from 'react';
+import { faviconRootFallback } from '@/utils/favicon';
 
 // Neutral initial avatar, swapped for the favicon only once it loads. Google's "no favicon"
-// placeholder is a ~16px globe, so reject anything that small to avoid the blurry globe.
+// placeholder is a ~16px globe, so reject anything that small to avoid the blurry globe. When the
+// primary favicon 404s or is too small (some dashboard subdomains have none), fall back to the
+// registrable domain's icon before settling on the initial.
 export function ProviderIcon({
   name,
   src,
@@ -11,24 +14,45 @@ export function ProviderIcon({
   src: string | null;
   size?: number;
 }) {
-  // Keyed by the src it was loaded for: when src changes, the derived favicon below falls back
-  // to the initial immediately during render — no reset effect, no flash of the previous icon.
-  const [loaded, setLoaded] = useState<{ src: string; ok: boolean } | null>(null);
+  const fallback = faviconRootFallback(src);
+  const key = `${src ?? ''}|${fallback ?? ''}`;
+  // Keyed by the candidates it was resolved for: when they change, the favicon below falls back to
+  // the initial immediately during render — no reset effect, no flash of the previous icon.
+  const [resolved, setResolved] = useState<{ key: string; src: string | null }>({
+    key: '',
+    src: null,
+  });
 
   useEffect(() => {
-    if (!src) return;
-    const img = new Image();
-    img.onload = () => {
-      setLoaded({ src, ok: img.naturalWidth > 16 });
+    const candidates = [src, fallback].filter((c): c is string => !!c);
+    if (candidates.length === 0) {
+      setResolved({ key, src: null });
+      return;
+    }
+    let cancelled = false;
+    const tryAt = (i: number) => {
+      if (i >= candidates.length) {
+        if (!cancelled) setResolved({ key, src: null });
+        return;
+      }
+      const img = new Image();
+      img.onload = () => {
+        if (cancelled) return;
+        if (img.naturalWidth > 16) setResolved({ key, src: candidates[i] });
+        else tryAt(i + 1);
+      };
+      img.onerror = () => {
+        if (!cancelled) tryAt(i + 1);
+      };
+      img.src = candidates[i];
     };
-    img.src = src;
+    tryAt(0);
     return () => {
-      // A stale onload must not clobber the state that belongs to the current src.
-      img.onload = null;
+      cancelled = true;
     };
-  }, [src]);
+  }, [key, src, fallback]);
 
-  const favicon = loaded && loaded.src === src && loaded.ok ? src : null;
+  const favicon = resolved.key === key ? resolved.src : null;
   const initial = (name.trim().charAt(0) || '?').toUpperCase();
 
   // Favicon and initial share one framed tile, so rows never mix icon footprints

--- a/apps/frontend/src/constants.ts
+++ b/apps/frontend/src/constants.ts
@@ -34,6 +34,7 @@ const PROVIDER_KINDS: ProviderKind[] = [
   'vdsina',
   'cloudflare',
   'stormwall',
+  'yandex',
   'manual',
 ];
 

--- a/apps/frontend/src/i18n/locales/providers.ts
+++ b/apps/frontend/src/i18n/locales/providers.ts
@@ -71,6 +71,25 @@ export const providers = {
         'Cloudflare → My Profile → API Tokens → create a token with Registrar: Domains:Read and Billing:Read',
       cloudflareAccountIdDesc: 'Cloudflare account ID (dashboard URL or GET /accounts)',
       apiTokenDescStormwall: 'StormWall personal cabinet → API key, sent as the x-api-key header',
+      yandexKey: 'Authorized key (JSON)',
+      yandexKeySetup: 'Setup:',
+      yandexKeyStep1:
+        'Go to center.yandex.cloud and open "All services" → "Monitoring & Resources" → "Identity and Access Management" → "Service accounts".',
+      yandexKeyStep2:
+        'Click "Create service account", enter any name, then "Roles in the folder" → "Add role" → "viewer", and finish with "Create".',
+      yandexKeyStep3:
+        'Open the service account you just created from the table, choose "Create new key" → "Create authorized key" → "Create" → "Download file with keys", and paste the downloaded key below.',
+      yandexKeyStep4:
+        'Back on center.yandex.cloud, open "Billing" → "Access management" → "Assign roles". In "Who to grant access to" pick this service account, in "Roles" choose "billing.accounts.viewer", and finish with "Save" (this also enables balance and consumption history).',
+      yandexScope: 'Detected scope',
+      yandexScopeDesc:
+        'Resolved automatically from the key: the folders scanned for servers and the billing account used for balance and consumption.',
+      yandexScopeFolders: 'Folder',
+      yandexScopeBilling: 'Billing account',
+      yandexScopeNone: 'Nothing found - check the service account roles.',
+      yandexScopeRefresh: 'Refresh',
+      yandexScopeLoading: 'Resolving...',
+      yandexScopePending: 'Paste the authorized key to detect the scope.',
       refreshToken: 'Refresh token (OAuth2)',
       refreshTokenDescNetcup:
         'Use “Authorize via netcup” above, or paste an offline refresh token manually',
@@ -104,6 +123,7 @@ export const providers = {
       vdsinaToken: 'Enter the VDSina API token',
       cloudflareCreds: 'Enter the Cloudflare account ID and API token',
       stormwallToken: 'Enter the StormWall API key',
+      yandexKey: 'Paste the Yandex Cloud service account authorized key (JSON)',
     },
     netcup: {
       authorize: 'Authorize via netcup',
@@ -198,6 +218,25 @@ export const providers = {
       cloudflareAccountIdDesc: 'Account ID аккаунта Cloudflare (из URL дашборда или GET /accounts)',
       apiTokenDescStormwall:
         'Личный кабинет StormWall → API-ключ (передаётся в заголовке x-api-key)',
+      yandexKey: 'Авторизованный ключ (JSON)',
+      yandexKeySetup: 'Настройка:',
+      yandexKeyStep1:
+        'Зайдите на center.yandex.cloud и выберите "All services" → "Monitoring & Resources" → "Identity and Access Management" → "Service accounts".',
+      yandexKeyStep2:
+        'Нажмите "Create service account", введите любое имя, затем "Roles in the folder" → "Add role" → "viewer" и завершите через "Create".',
+      yandexKeyStep3:
+        'Откройте созданный сервисный аккаунт в таблице, выберите "Create new key" → "Create authorized key" → "Create" → "Download file with keys" и вставьте полученный ключ ниже.',
+      yandexKeyStep4:
+        'Вернитесь на center.yandex.cloud, выберите "Billing" → "Access management" → "Assign roles". В поле "Who to grant access to" выберите этот сервисный аккаунт, в поле "Roles" выберите "billing.accounts.viewer", и завершите через "Save" (это же включает баланс и историю расходов).',
+      yandexScope: 'Определённая область',
+      yandexScopeDesc:
+        'Определяется автоматически по ключу: каталоги, из которых берутся серверы, и платёжный аккаунт для баланса и расходов.',
+      yandexScopeFolders: 'Каталог',
+      yandexScopeBilling: 'Платёжный аккаунт',
+      yandexScopeNone: 'Ничего не найдено - проверьте роли сервисного аккаунта.',
+      yandexScopeRefresh: 'Обновить',
+      yandexScopeLoading: 'Определяем...',
+      yandexScopePending: 'Вставьте авторизованный ключ, чтобы определить область.',
       refreshToken: 'Refresh-токен (OAuth2)',
       refreshTokenDescNetcup:
         'Нажмите «Авторизоваться через netcup» выше или вставьте offline refresh-токен вручную',
@@ -231,6 +270,7 @@ export const providers = {
       vdsinaToken: 'Укажите API-токен VDSina',
       cloudflareCreds: 'Укажите account ID и API-токен Cloudflare',
       stormwallToken: 'Укажите API-ключ StormWall',
+      yandexKey: 'Вставьте авторизованный ключ сервисного аккаунта Yandex Cloud (JSON)',
     },
     netcup: {
       authorize: 'Авторизоваться через netcup',

--- a/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
+++ b/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
@@ -1,16 +1,33 @@
-import { IconExternalLink } from '@tabler/icons-react';
-import type { ReactNode } from 'react';
+import {
+  type Icon,
+  IconExternalLink,
+  IconGridDots,
+  IconKey,
+  IconPlus,
+  IconRefresh,
+  IconRobot,
+} from '@tabler/icons-react';
+import { Fragment, type ReactNode } from 'react';
+import type { YandexDiscover } from '@infra/shared';
 import type { UseFormReturn } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { apiErrorMessage } from '@/api/client';
+import { useYandexDiscover } from '@/api/providers';
 import { NetcupAuthorizeButton } from '@/components/NetcupAuthorizeButton';
 import { PasswordInput } from '@/components/PasswordInput';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
 import type { FormValues } from './providerForm';
 
 interface ProviderCredentialFieldsProps {
   form: UseFormReturn<FormValues>;
   editing: boolean;
+  // Set in the edit modal so Yandex discovery can reuse the stored key without re-pasting it.
+  providerUuid?: string;
 }
 
 /** Field wrapper: label plus an optional description and credential deep link above the input. */
@@ -23,7 +40,7 @@ function Field({
 }: {
   id: string;
   label: string;
-  description?: string;
+  description?: ReactNode;
   link?: string;
   children: ReactNode;
 }) {
@@ -31,9 +48,9 @@ function Field({
     <div className="space-y-2">
       <Label htmlFor={id}>{label}</Label>
       {(description || link) && (
-        <p className="text-xs text-muted-foreground">
+        <div className="text-xs text-muted-foreground">
           {description}
-          {description && link && ' — '}
+          {typeof description === 'string' && link && ' — '}
           {link && (
             <a
               href={link}
@@ -45,20 +62,147 @@ function Field({
               <IconExternalLink className="size-3" />
             </a>
           )}
-        </p>
+        </div>
       )}
       {children}
     </div>
   );
 }
 
+// Render a Yandex setup step, turning the "center.yandex.cloud" mention into a link. Steps without
+// it are returned unchanged.
+function linkifyCenter(text: string): ReactNode {
+  const marker = 'center.yandex.cloud';
+  const idx = text.indexOf(marker);
+  if (idx === -1) return text;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <a
+        href="https://center.yandex.cloud"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-brand underline underline-offset-4 hover:no-underline"
+      >
+        {marker}
+      </a>
+      {text.slice(idx + marker.length)}
+    </>
+  );
+}
+
+// Yandex Console UI labels quoted in the setup steps, styled to look like the real controls: blue
+// primary buttons for actions, a leading icon for the few recognizable menu entries. Keyed by the
+// exact English label (the console is English regardless of the app locale).
+const YA_PRIMARY = new Set([
+  'Create service account',
+  'Create',
+  'Create new key',
+  'Assign roles',
+  'Save',
+]);
+// Solid dark-grey buttons (filled with what is just an outline elsewhere).
+const YA_FILLED = new Set(['Add role', 'Create authorized key']);
+// Grey-blue role chips (no border), like a selected tag on the site.
+const YA_CHIP = new Set(['viewer', 'billing.accounts.viewer']);
+// Left-column category headers in the "All services" menu, each with its own gradient on the site.
+const YA_SECTION: Record<string, string> = {
+  'Monitoring & Resources': 'bg-gradient-to-r from-slate-600 to-slate-800 text-white',
+  Billing: 'bg-gradient-to-br from-[#2f4d7a] to-[#22395d] text-white',
+};
+const YA_ICON: Record<string, Icon> = {
+  'All services': IconGridDots,
+  'Identity and Access Management': IconKey,
+  'Service accounts': IconRobot,
+  'Add role': IconPlus,
+};
+
+// The classes that make a quoted label look like its real Console control.
+function tokenClass(label: string): string {
+  if (YA_PRIMARY.has(label)) return 'bg-gradient-to-b from-[#4a86bd] to-[#3c72a4] text-white';
+  if (YA_FILLED.has(label)) return 'bg-[#3a3a3e] text-white';
+  if (YA_CHIP.has(label)) return 'bg-[#4b5666] text-[#cdd5e0]';
+  const section = YA_SECTION[label];
+  if (section) return section;
+  return 'bg-white/[0.07] text-foreground ring-1 ring-white/10 ring-inset';
+}
+
+// Render one quoted Console label as a badge that mimics its on-site look.
+function YaToken({ label }: { label: string }) {
+  const LabelIcon = YA_ICON[label];
+  return (
+    <span
+      className={cn(
+        'mx-0.5 inline-flex items-center gap-1 rounded-md px-1 py-0.5 align-middle text-[0.8em] font-medium leading-none whitespace-nowrap',
+        tokenClass(label),
+      )}
+    >
+      {LabelIcon && <LabelIcon className="size-3 shrink-0" />}
+      {label}
+    </span>
+  );
+}
+
+// Turn a setup step into React nodes: each "quoted" Console label becomes a YaToken badge, and the
+// plain text between them keeps the center.yandex.cloud link.
+function renderYaStep(text: string): ReactNode {
+  const parts: ReactNode[] = [];
+  const re = /"([^"]+)"/g;
+  let last = 0;
+  let key = 0;
+  let m: RegExpExecArray | null = re.exec(text);
+  while (m !== null) {
+    if (m.index > last) {
+      parts.push(<Fragment key={key++}>{linkifyCenter(text.slice(last, m.index))}</Fragment>);
+    }
+    parts.push(<YaToken key={key++} label={m[1]} />);
+    last = m.index + m[0].length;
+    m = re.exec(text);
+  }
+  if (last < text.length) {
+    parts.push(<Fragment key={key++}>{linkifyCenter(text.slice(last))}</Fragment>);
+  }
+  return parts;
+}
+
+// A pasted Yandex authorized key is only worth a discovery call once it parses into the fields the
+// backend signs the JWT with. Guards against firing on every keystroke of a half-pasted key.
+function isCompleteYandexKey(raw: string): boolean {
+  try {
+    const o = JSON.parse(raw) as Record<string, unknown>;
+    return Boolean(o.id && o.service_account_id && o.private_key);
+  } catch {
+    return false;
+  }
+}
+
 // The per-connector credential inputs, switched on the selected kind. Secret inputs use the
 // "keep empty to keep unchanged" placeholder when editing.
-export function ProviderCredentialFields({ form, editing }: ProviderCredentialFieldsProps) {
+export function ProviderCredentialFields({
+  form,
+  editing,
+  providerUuid,
+}: ProviderCredentialFieldsProps) {
   const { t } = useTranslation();
   const kind = form.watch('kind');
   const keepEmpty = editing ? t('providers.keepEmpty') : '';
   const keepEmptyOrOptional = editing ? t('providers.keepEmpty') : t('common.optional');
+
+  // Yandex scope badges: the connector auto-resolves the folders it scans for servers and the
+  // billing account it reads, so we just surface them read-only. Resolved from the entered key
+  // (create) or the stored provider (edit, empty field = keep the key unchanged). A keyed query so
+  // the result is cached per input and survives StrictMode's double mount.
+  const yandexToken = form.watch('token');
+  const yandexBody: YandexDiscover | null =
+    kind !== 'yandex'
+      ? null
+      : yandexToken && isCompleteYandexKey(yandexToken)
+        ? { token: yandexToken }
+        : !yandexToken && providerUuid
+          ? { providerUuid }
+          : null;
+  const discover = useYandexDiscover(yandexBody);
+  const yandexScope = discover.data ?? null;
 
   if (kind === 'selectel') {
     return (
@@ -347,6 +491,100 @@ export function ProviderCredentialFields({ form, editing }: ProviderCredentialFi
             {...form.register('secretKey')}
           />
         </Field>
+      </>
+    );
+  }
+
+  if (kind === 'yandex') {
+    return (
+      <>
+        <Field
+          id="cred-token"
+          label={t('providers.field.yandexKey')}
+          description={
+            <>
+              <span className="font-medium">{t('providers.field.yandexKeySetup')}</span>
+              <ol className="mt-1 list-decimal space-y-1.5 pl-4 leading-7">
+                <li>{renderYaStep(t('providers.field.yandexKeyStep1'))}</li>
+                <li>{renderYaStep(t('providers.field.yandexKeyStep2'))}</li>
+                <li>{renderYaStep(t('providers.field.yandexKeyStep3'))}</li>
+                <li>{renderYaStep(t('providers.field.yandexKeyStep4'))}</li>
+              </ol>
+            </>
+          }
+        >
+          <Textarea
+            id="cred-token"
+            rows={7}
+            className="font-mono text-xs"
+            placeholder={
+              editing
+                ? t('providers.keepEmpty')
+                : '{\n  "id": "...",\n  "service_account_id": "...",\n  "key_algorithm": "...",\n  "public_key": "...",\n  "private_key": "..."\n}'
+            }
+            {...form.register('token')}
+          />
+        </Field>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label>{t('providers.field.yandexScope')}</Label>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={discover.isFetching || !yandexBody}
+              onClick={() => discover.refetch()}
+            >
+              <IconRefresh className={discover.isFetching ? 'size-4 animate-spin' : 'size-4'} />
+              {t('providers.field.yandexScopeRefresh')}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">{t('providers.field.yandexScopeDesc')}</p>
+          {discover.isError ? (
+            <p className="text-xs text-destructive">{apiErrorMessage(discover.error)}</p>
+          ) : yandexScope ? (
+            <div className="space-y-3 rounded-md border p-3">
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium text-muted-foreground">
+                  {t('providers.field.yandexScopeFolders')}
+                </p>
+                {yandexScope.folders.length > 0 ? (
+                  <div className="flex flex-wrap gap-1.5">
+                    {yandexScope.folders.map((f) => (
+                      <Badge key={f.id} variant="secondary" className="font-mono">
+                        {f.id}
+                      </Badge>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    {t('providers.field.yandexScopeNone')}
+                  </p>
+                )}
+              </div>
+              <div className="space-y-1.5">
+                <p className="text-xs font-medium text-muted-foreground">
+                  {t('providers.field.yandexScopeBilling')}
+                </p>
+                {yandexScope.billingAccount ? (
+                  <Badge variant="secondary" className="font-mono">
+                    {yandexScope.billingAccount.id}
+                  </Badge>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    {t('providers.field.yandexScopeNone')}
+                  </p>
+                )}
+              </div>
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              {discover.isFetching
+                ? t('providers.field.yandexScopeLoading')
+                : t('providers.field.yandexScopePending')}
+            </p>
+          )}
+        </div>
       </>
     );
   }

--- a/apps/frontend/src/pages/providers/ProviderDetailModal.tsx
+++ b/apps/frontend/src/pages/providers/ProviderDetailModal.tsx
@@ -88,7 +88,12 @@ export function ProviderDetailModal({
         <div className="-mr-1 overflow-y-auto pr-1">
           <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_280px]">
             <form id="provider-detail-form" onSubmit={onSubmit} className="space-y-4">
-              <ProviderFormFields form={form} editing kindOptions={kindOptions} />
+              <ProviderFormFields
+                form={form}
+                editing
+                kindOptions={kindOptions}
+                providerUuid={shown.uuid}
+              />
             </form>
 
             <div className="space-y-4">

--- a/apps/frontend/src/pages/providers/ProviderFormFields.tsx
+++ b/apps/frontend/src/pages/providers/ProviderFormFields.tsx
@@ -19,10 +19,17 @@ interface ProviderFormFieldsProps {
   form: UseFormReturn<FormValues>;
   editing: boolean;
   kindOptions: { value: string; label: string }[];
+  // Passed in edit mode so Yandex discovery can reuse the stored key.
+  providerUuid?: string;
 }
 
 // The provider form body, shared by the create modal and the detail modal (editing mode).
-export function ProviderFormFields({ form, editing, kindOptions }: ProviderFormFieldsProps) {
+export function ProviderFormFields({
+  form,
+  editing,
+  kindOptions,
+  providerUuid,
+}: ProviderFormFieldsProps) {
   const { t } = useTranslation();
   const nameError = form.formState.errors.name;
   const kind = form.watch('kind');
@@ -125,7 +132,7 @@ export function ProviderFormFields({ form, editing, kindOptions }: ProviderFormF
       {/* Manual providers have no credentials — skip the empty section shell. */}
       {kind !== 'manual' && (
         <FormSection icon={IconKey} title={t('providers.section.credentials')}>
-          <ProviderCredentialFields form={form} editing={editing} />
+          <ProviderCredentialFields form={form} editing={editing} providerUuid={providerUuid} />
         </FormSection>
       )}
     </>

--- a/apps/frontend/src/pages/providers/providerForm.ts
+++ b/apps/frontend/src/pages/providers/providerForm.ts
@@ -37,6 +37,7 @@ export const DEFAULT_LOGIN_URLS: Record<string, string> = {
   vdsina: 'https://cp.vdsina.ru',
   cloudflare: 'https://dash.cloudflare.com',
   porkbun: 'https://porkbun.com/account',
+  yandex: 'https://console.yandex.cloud',
 };
 
 export const EMPTY_FORM: FormValues = {
@@ -74,6 +75,7 @@ export function validateProviderCredentials(v: FormValues, t: TFunction): string
   if (v.kind === 'cloudflare' && !(v.accountId && v.token))
     return t('providers.err.cloudflareCreds');
   if (v.kind === 'stormwall' && !v.token) return t('providers.err.stormwallToken');
+  if (v.kind === 'yandex' && !v.token) return t('providers.err.yandexKey');
   return null;
 }
 

--- a/apps/frontend/src/utils/favicon.ts
+++ b/apps/frontend/src/utils/favicon.ts
@@ -1,10 +1,30 @@
 // Favicon via Google s2 (same approach as Remnawave's favicon-resolver).
+const S2_PREFIX = 'https://www.google.com/s2/favicons?sz=64&domain_url=';
+
 function faviconResolver(link: string | null | undefined): string | null {
   if (!link) return null;
   try {
     const url = new URL(link.startsWith('http') ? link : `https://${link}`);
     if (!url.host) return null;
-    return `https://www.google.com/s2/favicons?sz=64&domain_url=${url.protocol}//${url.host}`;
+    return `${S2_PREFIX}${url.protocol}//${url.host}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Favicon for the registrable domain, dropping one subdomain label (console.yandex.cloud →
+ * yandex.cloud). Google's s2 service 404s for some dashboard subdomains (e.g. console.yandex.cloud)
+ * while it has the root domain's icon, so this is tried as a fallback when the primary fails to
+ * load. Returns null when `src` isn't an s2 URL or the host has no subdomain to strip.
+ */
+export function faviconRootFallback(src: string | null): string | null {
+  if (!src?.startsWith(S2_PREFIX)) return null;
+  try {
+    const url = new URL(src.slice(S2_PREFIX.length));
+    const labels = url.host.split('.');
+    if (labels.length < 3) return null;
+    return `${S2_PREFIX}${url.protocol}//${labels.slice(1).join('.')}`;
   } catch {
     return null;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
       "name": "@infra/backend",
       "version": "0.28.1",
       "dependencies": {
+        "@grpc/grpc-js": "^1.14.4",
+        "@grpc/proto-loader": "^0.8.1",
         "@infra/shared": "*",
         "@nestjs/common": "^11.1.27",
         "@nestjs/core": "^11.1.27",
@@ -1248,6 +1250,37 @@
       "integrity": "sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==",
       "license": "MIT"
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@hexagon/base64": {
       "version": "1.1.28",
       "resolved": "https://registry.npmjs.org/@hexagon/base64/-/base64-1.1.28.tgz",
@@ -1699,6 +1732,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/@kurkle/color": {
@@ -2527,6 +2570,63 @@
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.2",
@@ -9044,7 +9144,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9054,7 +9153,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -9690,6 +9788,37 @@
         "node": ">= 12"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
@@ -9726,7 +9855,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -9739,7 +9867,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -10373,7 +10500,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/empathic": {
@@ -10544,7 +10670,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11084,6 +11209,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -11591,7 +11725,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12211,6 +12344,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -13366,6 +13505,29 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -14076,6 +14238,15 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -14688,7 +14859,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -14703,7 +14873,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16383,6 +16552,15 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -16390,11 +16568,28 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-/** Connector kinds. API-backed: timeweb, hetzner, netcup, hostbill, billmgr, selectel, 4vps, netlen, beget, porkbun, vultr, linode, aeza, vdsina, cloudflare, stormwall. manual = no sync. */
+/** Connector kinds. API-backed: timeweb, hetzner, netcup, hostbill, billmgr, selectel, 4vps, netlen, beget, porkbun, vultr, linode, aeza, vdsina, cloudflare, stormwall, yandex. manual = no sync. */
 export const providerKindSchema = z.enum([
   'timeweb',
   'hetzner',
@@ -18,6 +18,7 @@ export const providerKindSchema = z.enum([
   'vdsina',
   'cloudflare',
   'stormwall',
+  'yandex',
   'manual',
 ]);
 export type ProviderKind = z.infer<typeof providerKindSchema>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,7 @@ export * from './controllers-info';
 export * from './schemas/common';
 export * from './schemas/provider';
 export * from './schemas/netcup';
+export * from './schemas/yandex';
 export * from './schemas/project';
 export * from './schemas/service';
 export * from './schemas/payment';

--- a/packages/shared/src/routes.ts
+++ b/packages/shared/src/routes.ts
@@ -51,6 +51,8 @@ export const API_SUB = {
   // netcup OAuth2 device flow (in-panel token acquisition).
   PROVIDER_NETCUP_DEVICE_START: 'netcup/device/start',
   PROVIDER_NETCUP_DEVICE_POLL: 'netcup/device/poll',
+  // Yandex Cloud folder / billing-account discovery for the form dropdowns.
+  PROVIDER_YANDEX_DISCOVER: 'yandex/discover',
   ANALYTICS_SUMMARY: 'summary',
   ANALYTICS_FORECAST: 'forecast',
   RATES_REFRESH: 'refresh',
@@ -90,6 +92,7 @@ export const API_PATH = {
       pathId(API.PROVIDERS, API_SUB.PROVIDER_BALANCE_HISTORY, uuid),
     NETCUP_DEVICE_START: path(API.PROVIDERS, API_SUB.PROVIDER_NETCUP_DEVICE_START),
     NETCUP_DEVICE_POLL: path(API.PROVIDERS, API_SUB.PROVIDER_NETCUP_DEVICE_POLL),
+    YANDEX_DISCOVER: path(API.PROVIDERS, API_SUB.PROVIDER_YANDEX_DISCOVER),
   },
   PROJECTS: {
     ROOT: path(API.PROJECTS),

--- a/packages/shared/src/schemas/yandex.ts
+++ b/packages/shared/src/schemas/yandex.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { uuidSchema } from './common';
+
+// Yandex Cloud scope discovery. Resolves the folders that will be scanned for servers and the
+// billing account used for balance / consumption, from the entered authorized key (create flow) or
+// from the stored credentials of an existing provider (edit flow). One of `token` / `providerUuid`
+// must be present.
+
+export const yandexDiscoverSchema = z
+  .object({
+    token: z.string().min(1).describe('Authorized key JSON (create flow)').optional(),
+    providerUuid: uuidSchema.describe('Existing provider UUID (edit flow)').optional(),
+  })
+  .refine((v) => Boolean(v.token || v.providerUuid), {
+    message: 'Provide the authorized key or an existing provider',
+  });
+export type YandexDiscover = z.infer<typeof yandexDiscoverSchema>;
+
+export const yandexResourceSchema = z.object({
+  id: z.string().describe('Resource id'),
+  name: z.string().describe('Display name'),
+});
+export type YandexResource = z.infer<typeof yandexResourceSchema>;
+
+export const yandexDiscoverResultSchema = z.object({
+  folders: z.array(yandexResourceSchema).describe('Folders that will be scanned for servers'),
+  billingAccount: yandexResourceSchema
+    .nullable()
+    .describe('Billing account used for balance / consumption'),
+});
+export type YandexDiscoverResult = z.infer<typeof yandexDiscoverResultSchema>;


### PR DESCRIPTION
Add Yandex Cloud as a new provider.

<img width="300" src="https://github.com/user-attachments/assets/0ab99960-70d6-468f-8edf-cc98dcf057a4" /><br>
<img width="300" src="https://github.com/user-attachments/assets/d11b3bc6-33f5-4e55-90cb-bc4608295630" />
<br>
<img width="300" src="https://github.com/user-attachments/assets/37e0284f-d403-4501-b4c6-64646e9da9fe" />
<br>
<img width="300" src="https://github.com/user-attachments/assets/0e124dcc-f370-4b01-9fd3-f1466f588c3d" />
<br>
<img width="300" src="https://github.com/user-attachments/assets/0a610809-a267-4b1c-96c7-8a4146249943" />

Authentication
- Uses a service account authorized key (JSON).
- Signs a PS256 JWT and exchanges it for a short-lived IAM token.

Data it syncs
- Balance and currency from the Billing API (first active billing account).
- Servers from the Compute API.
- Per-server monthly cost = last full month's actual consumption, pulled per resource from the gRPC Billing Usage API (Compute is usage-billed, so the Compute API exposes no fixed price).
- Next billing date = start of next month (when Yandex closes the billing period), the same for every server.
- Daily consumption history from the gRPC-only Billing Usage API (one charge per day).

Scope resolution
- The connector auto-resolves everything; no manual folder or billing account input.
- Servers come from the service account's own home folder (resolved from its service_account_id via IAM) - the folder the key already grants access to.
- Billing account is the first active one.
- A discover endpoint returns the resolved scope for the form to show.

UI
- Provider form shows the resolved folder and billing account as read-only badges.
- Scope is fetched automatically from the pasted key or the stored key when editing, via a cached query so the result survives React's remount.
- Setup instructions render Yandex Console labels as on-brand badges (buttons, chips, section headers).
- Provider favicon falls back to the registrable domain when the dashboard subdomain has no icon (console.yandex.cloud -> yandex.cloud).
- Removed the old folder id and billing account input fields.

--

Dashboard
- Consumption-only providers now count their charges toward total spend when they have no top-ups.
- This avoids double counting for providers that expose top-ups.