### PR TITLE
feat(providers): doubleservers, setup badges, and credential reveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ curl -H "Authorization: Bearer ib_…" https://infra-billing/api/providers
 - **StormWall** — API-ключ (личный кабинет → API-ключ). DDoS-защита/WAF: баланса, цен и платежей
   в API нет вообще (услуги вводятся с ценой вручную) — тянет только список услуг (`/v3/services`),
   для защищённых доменов — их реальное имя.
+- **Double Servers** — email + пароль от ЛК (`doubleservers.com/login`). Опц. TOTP-секрет, если
+  включена 2FA по приложению. Тянет баланс (EUR), VPS (цена, дата продления `expires_at`) и
+  историю: пополнения (`/api/billing/history`) + списания по серверам (`/api/servers/{id}/history`).
+  Публичного API-токена нет — синк логинится в панель.
 - **Manual** — без API, всё вводится руками.
 
 ## Telegram-уведомления

--- a/apps/backend/src/connectors/connector.factory.ts
+++ b/apps/backend/src/connectors/connector.factory.ts
@@ -9,6 +9,8 @@ import type { BillmgrCredentials } from './billmgr/billmgr.types';
 import { CloudflareConnector } from './cloudflare/cloudflare.connector';
 import type { CloudflareCredentials } from './cloudflare/cloudflare.types';
 import { Connector } from './connector.interface';
+import { DoubleServersConnector } from './doubleservers/doubleservers.connector';
+import type { DoubleServersCredentials } from './doubleservers/doubleservers.types';
 import { HetznerConnector } from './hetzner/hetzner.connector';
 import { HostbillConnector } from './hostbill/hostbill.connector';
 import type { HostbillCredentials } from './hostbill/hostbill.types';
@@ -85,6 +87,9 @@ export class ConnectorFactory {
         // Yandex Cloud secret is JSON: { keyId, serviceAccountId, privateKey, folderId?,
         // billingAccountId? }, normalized from the service-account authorized key.
         return new YandexConnector(JSON.parse(token) as YandexCredentials);
+      case 'doubleservers':
+        // Double Servers secret is JSON: { username (email), password, totpSecret? }.
+        return new DoubleServersConnector(JSON.parse(token) as DoubleServersCredentials);
       default:
         throw new Error(`Connector for kind="${kind}" is not supported`);
     }

--- a/apps/backend/src/connectors/doubleservers/doubleservers.connector.ts
+++ b/apps/backend/src/connectors/doubleservers/doubleservers.connector.ts
@@ -1,0 +1,196 @@
+import axios, { type AxiosInstance } from 'axios';
+import Decimal from 'decimal.js';
+import { REQUEST_TIMEOUT_MS } from '../common/http';
+import { totpCode } from '../common/totp';
+import { Account, Connector, PaymentData, ServiceData } from '../connector.interface';
+import {
+  DOUBLESERVERS_CURRENCY,
+  mapDoubleServersCharge,
+  mapDoubleServersServer,
+  mapDoubleServersTopup,
+} from './doubleservers.mapper';
+import {
+  DoubleServersCredentials,
+  DoubleServersLoginResponse,
+  DoubleServersMe,
+  DoubleServersPage,
+  DoubleServersServer,
+  DoubleServersServerHistoryItem,
+  DoubleServersTopup,
+} from './doubleservers.types';
+
+const BASE_URL = 'https://doubleservers.com';
+const PAGE_SIZE = 100;
+const MAX_PAGES = 50;
+
+const TWO_FACTOR_MESSAGE =
+  'Double Servers: authenticator-app (TOTP) 2FA is enabled but no TOTP secret is set. Add the base32 TOTP ' +
+  'secret in the provider settings so the sync can generate the one-time code itself.';
+
+export class DoubleServersConnector implements Connector {
+  private readonly http: AxiosInstance;
+  private readonly creds: DoubleServersCredentials;
+  private token: string | null = null;
+
+  constructor(creds: DoubleServersCredentials) {
+    this.creds = creds;
+    this.http = axios.create({
+      baseURL: BASE_URL,
+      timeout: REQUEST_TIMEOUT_MS,
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    });
+    this.http.interceptors.response.use(undefined, (e) => {
+      if (axios.isAxiosError(e)) {
+        const body = e.response?.data as { detail?: unknown } | undefined;
+        const detail = formatDetail(body?.detail);
+        if (detail) throw new Error(`Double Servers: ${detail}`);
+      }
+      throw e;
+    });
+  }
+
+  kind(): string {
+    return 'doubleservers';
+  }
+
+  async fetchAccount(signal: AbortSignal): Promise<Account> {
+    const me = await this.getMe(signal);
+    return {
+      balance: new Decimal(String(me.balance ?? 0)),
+      currency: DOUBLESERVERS_CURRENCY,
+    };
+  }
+
+  async fetchServices(signal: AbortSignal): Promise<ServiceData[]> {
+    const { data } = await this.request<DoubleServersServer[]>('/api/servers', signal);
+    return (data ?? []).map(mapDoubleServersServer);
+  }
+
+  async fetchPayments(signal: AbortSignal): Promise<PaymentData[]> {
+    const [topups, serversRes] = await Promise.all([
+      this.paginateTopups(signal),
+      this.request<DoubleServersServer[]>('/api/servers', signal),
+    ]);
+    const servers = serversRes.data ?? [];
+    const out: PaymentData[] = [];
+    for (const t of topups) {
+      const mapped = mapDoubleServersTopup(t);
+      if (mapped) out.push(mapped);
+    }
+    const histories = await Promise.all(
+      servers.map((s) => this.paginateServerHistory(s.id, signal).then((items) => ({ s, items }))),
+    );
+    for (const { s, items } of histories) {
+      for (const item of items) {
+        const mapped = mapDoubleServersCharge(item, s.id);
+        if (mapped) out.push(mapped);
+      }
+    }
+    return out;
+  }
+
+  private async getMe(signal: AbortSignal): Promise<DoubleServersMe> {
+    const { data } = await this.request<DoubleServersMe>('/api/auth/me', signal);
+    return data;
+  }
+
+  private async authToken(signal: AbortSignal): Promise<string> {
+    if (this.token) return this.token;
+    let res = await this.login(undefined, signal);
+    if (res.totp_required) {
+      if (!this.creds.totpSecret) throw new Error(TWO_FACTOR_MESSAGE);
+      res = await this.login(totpCode(this.creds.totpSecret, Date.now()), signal);
+    }
+    if (!this.token) {
+      throw new Error(loginErrorMessage(res));
+    }
+    return this.token;
+  }
+
+  private async login(
+    totp: string | undefined,
+    signal: AbortSignal,
+  ): Promise<DoubleServersLoginResponse> {
+    const body: Record<string, string> = {
+      email: this.creds.username,
+      password: this.creds.password,
+    };
+    if (totp) body.totp_code = totp;
+    const res = await this.http.post<DoubleServersLoginResponse>('/api/auth/email/login', body, {
+      signal,
+      validateStatus: (s) => s < 500,
+    });
+    const data = res.data ?? {};
+    if (res.status >= 400) throw new Error(loginErrorMessage(data));
+    if (data.totp_required) return data;
+    const token = extractAccessToken(res.headers['set-cookie']);
+    if (!token) throw new Error('Double Servers: login succeeded but no access_token cookie was set');
+    this.token = token;
+    return data;
+  }
+
+  private async request<T>(path: string, signal: AbortSignal, params?: Record<string, unknown>) {
+    const token = await this.authToken(signal);
+    return this.http.get<T>(path, {
+      headers: { Authorization: `Bearer ${token}` },
+      params,
+      signal,
+    });
+  }
+
+  private async paginateTopups(signal: AbortSignal): Promise<DoubleServersTopup[]> {
+    return this.paginate<DoubleServersTopup>('/api/billing/history', signal);
+  }
+
+  private async paginateServerHistory(
+    serverId: number,
+    signal: AbortSignal,
+  ): Promise<DoubleServersServerHistoryItem[]> {
+    return this.paginate<DoubleServersServerHistoryItem>(
+      `/api/servers/${serverId}/history`,
+      signal,
+    );
+  }
+
+  private async paginate<T>(path: string, signal: AbortSignal): Promise<T[]> {
+    const out: T[] = [];
+    for (let page = 0; page < MAX_PAGES; page++) {
+      const { data } = await this.request<DoubleServersPage<T>>(path, signal, {
+        page,
+        per_page: PAGE_SIZE,
+      });
+      const items = data.items ?? [];
+      out.push(...items);
+      const totalPages = data.total_pages ?? 1;
+      if (page + 1 >= totalPages || items.length === 0) break;
+    }
+    return out;
+  }
+}
+
+function extractAccessToken(setCookie: string[] | string | undefined): string | null {
+  const parts = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : [];
+  for (const raw of parts) {
+    const m = /(?:^|,\s*)access_token=([^;]+)/.exec(raw);
+    if (m?.[1]) return m[1];
+  }
+  return null;
+}
+
+function formatDetail(detail: unknown): string | null {
+  if (typeof detail === 'string' && detail.trim()) return detail;
+  if (Array.isArray(detail)) {
+    const msgs = detail
+      .map((d) => (typeof d === 'string' ? d : (d as { msg?: string })?.msg))
+      .filter((m): m is string => !!m);
+    if (msgs.length) return msgs.join('; ');
+  }
+  return null;
+}
+
+function loginErrorMessage(res: DoubleServersLoginResponse): string {
+  const detail = formatDetail(res.detail);
+  if (detail) return `Double Servers: ${detail}`;
+  if (res.totp_required) return TWO_FACTOR_MESSAGE;
+  return 'Double Servers: login failed';
+}

--- a/apps/backend/src/connectors/doubleservers/doubleservers.mapper.ts
+++ b/apps/backend/src/connectors/doubleservers/doubleservers.mapper.ts
@@ -1,0 +1,104 @@
+import Decimal from 'decimal.js';
+import { PaymentData, ServiceData } from '../connector.interface';
+import {
+  DoubleServersServer,
+  DoubleServersServerHistoryItem,
+  DoubleServersTopup,
+} from './doubleservers.types';
+
+export const DOUBLESERVERS_CURRENCY = 'EUR';
+
+const COUNTRY_BY_NAME: Record<string, string> = {
+  germany: 'DE',
+  finland: 'FI',
+  france: 'FR',
+  netherlands: 'NL',
+  singapore: 'SG',
+  'united states': 'US',
+  usa: 'US',
+  poland: 'PL',
+  sweden: 'SE',
+  austria: 'AT',
+  switzerland: 'CH',
+  'united kingdom': 'GB',
+  uk: 'GB',
+};
+
+function parseDate(s?: string | null): Date | undefined {
+  if (!s) return undefined;
+  const d = new Date(s);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+export function mapDoubleServersCountry(
+  location?: string | null,
+  locationName?: string | null,
+): string | undefined {
+  const name = (locationName ?? '').split(',')[0]?.trim().toLowerCase();
+  if (name && COUNTRY_BY_NAME[name]) return COUNTRY_BY_NAME[name];
+  const loc = (location ?? '').toLowerCase();
+  if (loc.startsWith('ger') || loc.startsWith('fsn') || loc.startsWith('nbg')) return 'DE';
+  if (loc.startsWith('hel')) return 'FI';
+  if (loc.startsWith('ash') || loc.startsWith('hil')) return 'US';
+  if (loc.startsWith('sin')) return 'SG';
+  return undefined;
+}
+
+export function mapDoubleServersServer(s: DoubleServersServer): ServiceData {
+  return {
+    externalId: String(s.id),
+    name: s.name || `ds-${s.id}`,
+    type: 'vps',
+    countryCode: mapDoubleServersCountry(s.location, s.location_name),
+    cost: s.price != null ? new Decimal(String(s.price)) : undefined,
+    currency: DOUBLESERVERS_CURRENCY,
+    period: 'monthly',
+    nextBilling: parseDate(s.expires_at),
+    meta: {
+      ip: s.ip,
+      status: s.status,
+      frozen: s.frozen,
+      blocked: s.blocked,
+      autoRenew: s.auto_renew,
+      plan: s.plan,
+      location: s.location,
+      locationName: s.location_name,
+      hostProvider: s.provider,
+      os: s.os,
+      created: s.created_at,
+    },
+  };
+}
+
+export function mapDoubleServersTopup(t: DoubleServersTopup): PaymentData | null {
+  const date = parseDate(t.confirmed_at);
+  if (!date) return null;
+  return {
+    externalId: `topup:${t.transaction_id}`,
+    type: 'topup',
+    amount: new Decimal(String(t.amount_eur)),
+    currency: DOUBLESERVERS_CURRENCY,
+    date,
+    description: t.method ?? undefined,
+  };
+}
+
+export function mapDoubleServersCharge(
+  item: DoubleServersServerHistoryItem,
+  serverId: number,
+): PaymentData | null {
+  if ((item.kind ?? '').toLowerCase() !== 'debit') return null;
+  const date = parseDate(item.created_at);
+  if (!date) return null;
+  const amount = new Decimal(String(item.amount)).abs();
+  if (amount.lte(0)) return null;
+  return {
+    externalId: `charge:${item.id}`,
+    type: 'charge',
+    amount,
+    currency: DOUBLESERVERS_CURRENCY,
+    date,
+    description: item.description ?? item.type ?? undefined,
+    serviceExternalId: String(serverId),
+  };
+}

--- a/apps/backend/src/connectors/doubleservers/doubleservers.types.ts
+++ b/apps/backend/src/connectors/doubleservers/doubleservers.types.ts
@@ -1,0 +1,65 @@
+export interface DoubleServersCredentials {
+  username: string;
+  password: string;
+  totpSecret?: string;
+}
+
+export interface DoubleServersLoginResponse {
+  success?: boolean;
+  totp_required?: boolean;
+  user_id?: number;
+  username?: string;
+  detail?: string | { msg?: string }[];
+}
+
+export interface DoubleServersMe {
+  user_id: number;
+  username: string;
+  balance: number;
+  two_fa_enabled?: boolean;
+  two_fa_pending?: boolean;
+}
+
+export interface DoubleServersServer {
+  id: number;
+  name: string;
+  ip?: string | null;
+  provider?: string | null;
+  plan?: string | null;
+  location?: string | null;
+  location_name?: string | null;
+  status?: string | null;
+  frozen?: boolean;
+  blocked?: boolean;
+  auto_renew?: boolean;
+  expires_at?: string | null;
+  created_at?: string | null;
+  os?: string | null;
+  price?: number | null;
+}
+
+export interface DoubleServersPage<T> {
+  total: number;
+  page: number;
+  per_page: number;
+  total_pages: number;
+  items: T[];
+}
+
+export interface DoubleServersTopup {
+  transaction_id: string;
+  amount_rub: number;
+  amount_eur: number;
+  method?: string | null;
+  confirmed_at?: string | null;
+}
+
+export interface DoubleServersServerHistoryItem {
+  id: number;
+  created_at: string;
+  type?: string | null;
+  kind?: string | null;
+  amount: number;
+  balance_after?: number | null;
+  description?: string | null;
+}

--- a/apps/backend/src/providers/dto/provider.dto.ts
+++ b/apps/backend/src/providers/dto/provider.dto.ts
@@ -4,6 +4,7 @@ import {
   netcupDevicePollResultSchema,
   netcupDevicePollSchema,
   netcupDeviceStartSchema,
+  providerCredentialsRevealSchema,
   providerSchema,
   serviceSchema,
   updateProviderSchema,
@@ -22,5 +23,6 @@ export class ProviderDto extends createZodDto(providerSchema) {}
 export class ProviderWithServicesDto extends createZodDto(
   providerSchema.extend({ services: z.array(serviceSchema) }),
 ) {}
+export class ProviderCredentialsRevealDto extends createZodDto(providerCredentialsRevealSchema) {}
 export class NetcupDeviceStartDto extends createZodDto(netcupDeviceStartSchema) {}
 export class NetcupDevicePollResultDto extends createZodDto(netcupDevicePollResultSchema) {}

--- a/apps/backend/src/providers/providers.controller.ts
+++ b/apps/backend/src/providers/providers.controller.ts
@@ -17,6 +17,7 @@ import {
   NetcupDevicePollDto,
   NetcupDevicePollResultDto,
   NetcupDeviceStartDto,
+  ProviderCredentialsRevealDto,
   ProviderDto,
   ProviderWithServicesDto,
   UpdateProviderDto,
@@ -79,6 +80,13 @@ export class ProvidersController {
   @ApiOkResponse({ type: YandexDiscoverResultDto })
   yandexDiscover(@Body() dto: YandexDiscoverDto) {
     return this.providers.discoverYandex(dto);
+  }
+
+  @Get(API_SUB.PROVIDER_CREDENTIALS_REVEAL)
+  @ApiOperation({ summary: 'Reveal stored provider credentials (explicit reveal)' })
+  @ApiOkResponse({ type: ProviderCredentialsRevealDto })
+  revealCredentials(@Param(ID_PARAM, ParseUUIDPipe) uuid: string) {
+    return this.providers.revealCredentials(uuid);
   }
 
   @Get(API_SUB.BY_ID)

--- a/apps/backend/src/providers/providers.service.ts
+++ b/apps/backend/src/providers/providers.service.ts
@@ -57,8 +57,8 @@ export class ProvidersService {
       const c = this.decodeCredentials(enc);
       return { ...dto, baseUrl: c.baseUrl ?? null };
     }
-    if (kind === 'beget') {
-      // Only the login is a non-secret hint; never expose password/totpSecret/apiPassword.
+    if (kind === 'beget' || kind === 'doubleservers') {
+      // Only the login/email is a non-secret hint; never expose password/totpSecret/apiPassword.
       const c = this.decodeCredentials(enc);
       return { ...dto, username: c.username ?? null };
     }
@@ -202,6 +202,21 @@ export class ProvidersService {
       if (totpSecret) creds.totpSecret = totpSecret;
       const apiPassword = dto.apiPassword ?? base.apiPassword;
       if (apiPassword) creds.apiPassword = apiPassword;
+      return this.crypto.encrypt(JSON.stringify(creds));
+    }
+    if (kind === 'doubleservers') {
+      // JSON { username (email), password, totpSecret? }; merge so a partial edit works.
+      const supplied = dto.username || dto.password || dto.totpSecret;
+      if (!supplied) return null;
+      const base = this.decodeCredentials(existingEnc);
+      const username = dto.username ?? base.username;
+      const password = dto.password ?? base.password;
+      if (!username || !password) {
+        throw new BadRequestException('Provide the Double Servers email and password together');
+      }
+      const creds: Record<string, string> = { username, password };
+      const totpSecret = dto.totpSecret ?? base.totpSecret;
+      if (totpSecret) creds.totpSecret = totpSecret;
       return this.crypto.encrypt(JSON.stringify(creds));
     }
     if (kind === 'cloudflare') {

--- a/apps/backend/src/providers/providers.service.ts
+++ b/apps/backend/src/providers/providers.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from '@nestjs/comm
 import { Prisma } from '@generated/prisma/client';
 import {
   Provider as ProviderDto,
+  ProviderCredentialsReveal,
   Service as ServiceDto,
   YandexDiscoverResult,
 } from '@infra/shared';
@@ -35,42 +36,172 @@ export class ProvidersService {
     return { ...dto, services: p.services.map(mapService) };
   }
 
-  /** Expose non-secret credential fields (baseUrl/username/accountId) for the edit form. */
+  /** Expose non-secret hints + secret-presence flags for the edit form (never plaintext). */
   private withCredentialHints(dto: ProviderDto, kind: string, enc: Uint8Array | null): ProviderDto {
+    return {
+      ...dto,
+      ...this.nonSecretHints(kind, enc),
+      ...this.secretPresence(kind, enc),
+    };
+  }
+
+  private nonSecretHints(
+    kind: string,
+    enc: Uint8Array | null,
+  ): Partial<ProviderDto> {
     if (kind === 'selectel') {
       const c = this.decodeCredentials(enc);
-      // Never expose the password.
       return {
-        ...dto,
         accountId: c.accountId ?? null,
         username: c.username ?? null,
         projectName: c.projectName ?? null,
       };
     }
     if (kind === '4vps') {
-      // Never expose the token; panelId is a non-secret hint.
       const c = this.decodeCredentials(enc);
-      return { ...dto, panelId: c.panelId ?? null };
+      return { panelId: c.panelId ?? null };
     }
     if (kind === 'vdsina') {
-      // Never expose the token; the branch base URL is a non-secret hint.
       const c = this.decodeCredentials(enc);
-      return { ...dto, baseUrl: c.baseUrl ?? null };
+      return { baseUrl: c.baseUrl ?? null };
     }
     if (kind === 'beget' || kind === 'doubleservers') {
-      // Only the login/email is a non-secret hint; never expose password/totpSecret/apiPassword.
       const c = this.decodeCredentials(enc);
-      return { ...dto, username: c.username ?? null };
+      return { username: c.username ?? null };
     }
     if (kind === 'cloudflare') {
-      // accountId is a non-secret hint; never expose the apiToken.
       const c = this.decodeCredentials(enc);
-      return { ...dto, accountId: c.accountId ?? null };
+      return { accountId: c.accountId ?? null };
     }
-    if (kind !== 'hostbill' && kind !== 'billmgr') return dto;
+    if (kind === 'hostbill' || kind === 'billmgr') {
+      const c = this.decodeCredentials(enc);
+      return { baseUrl: c.baseUrl ?? null, username: c.username ?? null };
+    }
+    return {};
+  }
+
+  private secretPresence(kind: string, enc: Uint8Array | null): Partial<ProviderDto> {
+    if (kind === 'manual' || !enc) {
+      return {
+        hasToken: false,
+        hasPassword: false,
+        hasTotpSecret: false,
+        hasApiPassword: false,
+        hasSecretKey: false,
+      };
+    }
+    if (
+      kind === 'timeweb' ||
+      kind === 'hetzner' ||
+      kind === 'netcup' ||
+      kind === 'netlen' ||
+      kind === 'vultr' ||
+      kind === 'linode' ||
+      kind === 'aeza' ||
+      kind === 'stormwall'
+    ) {
+      return { hasToken: true };
+    }
     const c = this.decodeCredentials(enc);
-    // Never expose password/totpSecret.
-    return { ...dto, baseUrl: c.baseUrl ?? null, username: c.username ?? null };
+    if (kind === '4vps' || kind === 'vdsina') return { hasToken: Boolean(c.token) };
+    if (kind === 'cloudflare') return { hasToken: Boolean(c.apiToken) };
+    if (kind === 'porkbun') {
+      return { hasToken: Boolean(c.apiKey), hasSecretKey: Boolean(c.secretApiKey) };
+    }
+    if (kind === 'yandex') {
+      return { hasToken: Boolean(c.keyId && c.serviceAccountId && c.privateKey) };
+    }
+    if (kind === 'selectel' || kind === 'hostbill') {
+      return { hasPassword: Boolean(c.password) };
+    }
+    if (kind === 'billmgr') {
+      return { hasPassword: Boolean(c.password), hasTotpSecret: Boolean(c.totpSecret) };
+    }
+    if (kind === 'beget') {
+      return {
+        hasPassword: Boolean(c.password),
+        hasTotpSecret: Boolean(c.totpSecret),
+        hasApiPassword: Boolean(c.apiPassword),
+      };
+    }
+    if (kind === 'doubleservers') {
+      return { hasPassword: Boolean(c.password), hasTotpSecret: Boolean(c.totpSecret) };
+    }
+    return { hasToken: true };
+  }
+
+  /** Decrypt stored secrets for an explicit reveal (edit form eye toggle). */
+  async revealCredentials(uuid: string): Promise<ProviderCredentialsReveal> {
+    const existing = await this.providers.findCredentials(uuid);
+    if (!existing) throw new NotFoundException('Provider not found');
+    const { kind, credentialsEnc: enc } = existing;
+    if (!enc || kind === 'manual') return {};
+
+    if (
+      kind === 'timeweb' ||
+      kind === 'hetzner' ||
+      kind === 'netcup' ||
+      kind === 'netlen' ||
+      kind === 'vultr' ||
+      kind === 'linode' ||
+      kind === 'aeza' ||
+      kind === 'stormwall'
+    ) {
+      const token = this.decryptRaw(enc);
+      return token ? { token } : {};
+    }
+
+    const c = this.decodeCredentials(enc);
+    if (kind === '4vps' || kind === 'vdsina') {
+      return c.token ? { token: c.token } : {};
+    }
+    if (kind === 'cloudflare') {
+      return c.apiToken ? { token: c.apiToken } : {};
+    }
+    if (kind === 'porkbun') {
+      const out: ProviderCredentialsReveal = {};
+      if (c.apiKey) out.token = c.apiKey;
+      if (c.secretApiKey) out.secretKey = c.secretApiKey;
+      return out;
+    }
+    if (kind === 'yandex') {
+      if (!c.keyId || !c.serviceAccountId || !c.privateKey) return {};
+      return {
+        token: JSON.stringify(
+          {
+            id: c.keyId,
+            service_account_id: c.serviceAccountId,
+            private_key: c.privateKey,
+          },
+          null,
+          2,
+        ),
+      };
+    }
+    if (kind === 'selectel' || kind === 'hostbill') {
+      return c.password ? { password: c.password } : {};
+    }
+    if (kind === 'billmgr') {
+      const out: ProviderCredentialsReveal = {};
+      if (c.password) out.password = c.password;
+      if (c.totpSecret) out.totpSecret = c.totpSecret;
+      return out;
+    }
+    if (kind === 'beget') {
+      const out: ProviderCredentialsReveal = {};
+      if (c.password) out.password = c.password;
+      if (c.totpSecret) out.totpSecret = c.totpSecret;
+      if (c.apiPassword) out.apiPassword = c.apiPassword;
+      return out;
+    }
+    if (kind === 'doubleservers') {
+      const out: ProviderCredentialsReveal = {};
+      if (c.password) out.password = c.password;
+      if (c.totpSecret) out.totpSecret = c.totpSecret;
+      return out;
+    }
+    const token = this.decryptRaw(enc);
+    return token ? { token } : {};
   }
 
   async create(dto: CreateProviderDto): Promise<ProviderDto> {
@@ -335,6 +466,15 @@ export class ProvidersService {
       return JSON.parse(this.crypto.decrypt(enc)) as Record<string, string>;
     } catch {
       return {};
+    }
+  }
+
+  private decryptRaw(enc: Uint8Array): string | null {
+    try {
+      const raw = this.crypto.decrypt(enc);
+      return raw || null;
+    } catch {
+      return null;
     }
   }
 

--- a/apps/frontend/src/api/providers.ts
+++ b/apps/frontend/src/api/providers.ts
@@ -4,6 +4,7 @@ import type {
   NetcupDevicePollResult,
   NetcupDeviceStart,
   Provider,
+  ProviderCredentialsReveal,
   SyncRun,
   UpdateProvider,
   YandexDiscover,
@@ -13,6 +14,15 @@ import { api } from './client';
 import { API_PATH } from '@infra/shared';
 
 const KEY = ['providers'];
+
+export type SecretField = keyof ProviderCredentialsReveal;
+
+export async function revealProviderCredentials(
+  uuid: string,
+): Promise<ProviderCredentialsReveal> {
+  return (await api.get<ProviderCredentialsReveal>(API_PATH.PROVIDERS.CREDENTIALS_REVEAL(uuid)))
+    .data;
+}
 
 export function useProviders() {
   return useQuery({

--- a/apps/frontend/src/components/SecretInput.tsx
+++ b/apps/frontend/src/components/SecretInput.tsx
@@ -33,7 +33,8 @@ export function SecretInput({
   const [visible, setVisible] = useState(false);
   const [revealing, setRevealing] = useState(false);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const masked = Boolean(hasStored && !value);
+  // Fixed-length mask whenever a stored secret is hidden (never mirror real length).
+  const showMask = Boolean(hasStored && !visible);
 
   useEffect(() => {
     return () => {
@@ -47,17 +48,22 @@ export function SecretInput({
   };
 
   const toggle = async () => {
-    if (masked) {
-      if (!onReveal || revealing) return;
-      setRevealing(true);
-      try {
-        const secret = await onReveal();
-        onChange?.(secret);
-        setVisible(true);
-        scheduleHide();
-      } finally {
-        setRevealing(false);
+    if (showMask) {
+      if (!value) {
+        if (!onReveal || revealing) return;
+        setRevealing(true);
+        try {
+          const secret = await onReveal();
+          onChange?.(secret);
+          setVisible(true);
+          scheduleHide();
+        } finally {
+          setRevealing(false);
+        }
+        return;
       }
+      setVisible(true);
+      scheduleHide();
       return;
     }
     setVisible((v) => {
@@ -72,9 +78,12 @@ export function SecretInput({
     <button
       type="button"
       tabIndex={-1}
-      disabled={disabled || revealing || (masked && !onReveal)}
+      disabled={disabled || revealing || (showMask && !value && !onReveal)}
       aria-label={visible ? 'hide secret' : 'show secret'}
-      className="absolute inset-y-0 right-0 flex w-9 items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-50"
+      className={cn(
+        'absolute right-0 flex w-9 items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-50',
+        multiline && value && visible ? 'top-0 h-9' : 'inset-y-0',
+      )}
       onClick={() => void toggle()}
     >
       {revealing ? (
@@ -93,7 +102,12 @@ export function SecretInput({
         <Textarea
           id={inputId}
           rows={7}
-          className={cn('pr-9 font-mono text-xs', className)}
+          wrap="off"
+          spellCheck={false}
+          className={cn(
+            'overflow-x-auto pr-9 font-mono text-xs whitespace-pre [field-sizing:fixed]',
+            className,
+          )}
           value={value}
           disabled={disabled}
           autoComplete="off"
@@ -108,14 +122,14 @@ export function SecretInput({
     <div className="relative">
       <Input
         id={inputId}
-        type={masked ? 'text' : visible ? 'text' : 'password'}
+        type={showMask ? 'text' : visible ? 'text' : 'password'}
         className={cn('pr-9', multiline && 'font-mono text-xs', className)}
-        value={masked ? MASK : value}
-        readOnly={masked}
+        value={showMask ? MASK : value}
+        readOnly={showMask}
         disabled={disabled}
-        placeholder={masked ? undefined : placeholder}
+        placeholder={showMask ? undefined : placeholder}
         autoComplete="off"
-        onChange={masked ? undefined : (e) => onChange?.(e.target.value)}
+        onChange={showMask ? undefined : (e) => onChange?.(e.target.value)}
         {...rest}
       />
       {eye}

--- a/apps/frontend/src/components/SecretInput.tsx
+++ b/apps/frontend/src/components/SecretInput.tsx
@@ -1,0 +1,124 @@
+import { IconEye, IconEyeOff, IconLoader2 } from '@tabler/icons-react';
+import { useEffect, useId, useRef, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { cn } from '@/lib/utils';
+
+const MASK = '••••••••';
+const AUTO_HIDE_MS = 45_000;
+
+export interface SecretInputProps
+  extends Omit<React.ComponentProps<'input'>, 'type' | 'value' | 'onChange'> {
+  value?: string;
+  onChange?: (value: string) => void;
+  hasStored?: boolean;
+  onReveal?: () => Promise<string>;
+  multiline?: boolean;
+}
+
+export function SecretInput({
+  className,
+  value = '',
+  onChange,
+  hasStored = false,
+  onReveal,
+  multiline = false,
+  disabled,
+  id,
+  placeholder,
+  ...rest
+}: SecretInputProps) {
+  const autoId = useId();
+  const inputId = id ?? autoId;
+  const [visible, setVisible] = useState(false);
+  const [revealing, setRevealing] = useState(false);
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const masked = Boolean(hasStored && !value);
+
+  useEffect(() => {
+    return () => {
+      if (hideTimer.current) clearTimeout(hideTimer.current);
+    };
+  }, []);
+
+  const scheduleHide = () => {
+    if (hideTimer.current) clearTimeout(hideTimer.current);
+    hideTimer.current = setTimeout(() => setVisible(false), AUTO_HIDE_MS);
+  };
+
+  const toggle = async () => {
+    if (masked) {
+      if (!onReveal || revealing) return;
+      setRevealing(true);
+      try {
+        const secret = await onReveal();
+        onChange?.(secret);
+        setVisible(true);
+        scheduleHide();
+      } finally {
+        setRevealing(false);
+      }
+      return;
+    }
+    setVisible((v) => {
+      const next = !v;
+      if (next) scheduleHide();
+      else if (hideTimer.current) clearTimeout(hideTimer.current);
+      return next;
+    });
+  };
+
+  const eye = (
+    <button
+      type="button"
+      tabIndex={-1}
+      disabled={disabled || revealing || (masked && !onReveal)}
+      aria-label={visible ? 'hide secret' : 'show secret'}
+      className="absolute inset-y-0 right-0 flex w-9 items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-50"
+      onClick={() => void toggle()}
+    >
+      {revealing ? (
+        <IconLoader2 className="size-4 animate-spin" />
+      ) : visible ? (
+        <IconEyeOff className="size-4" />
+      ) : (
+        <IconEye className="size-4" />
+      )}
+    </button>
+  );
+
+  if (multiline && value && visible) {
+    return (
+      <div className="relative">
+        <Textarea
+          id={inputId}
+          rows={7}
+          className={cn('pr-9 font-mono text-xs', className)}
+          value={value}
+          disabled={disabled}
+          autoComplete="off"
+          onChange={(e) => onChange?.(e.target.value)}
+        />
+        {eye}
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <Input
+        id={inputId}
+        type={masked ? 'text' : visible ? 'text' : 'password'}
+        className={cn('pr-9', multiline && 'font-mono text-xs', className)}
+        value={masked ? MASK : value}
+        readOnly={masked}
+        disabled={disabled}
+        placeholder={masked ? undefined : placeholder}
+        autoComplete="off"
+        onChange={masked ? undefined : (e) => onChange?.(e.target.value)}
+        {...rest}
+      />
+      {eye}
+    </div>
+  );
+}

--- a/apps/frontend/src/constants.ts
+++ b/apps/frontend/src/constants.ts
@@ -35,6 +35,7 @@ const PROVIDER_KINDS: ProviderKind[] = [
   'cloudflare',
   'stormwall',
   'yandex',
+  'doubleservers',
   'manual',
 ];
 

--- a/apps/frontend/src/i18n/locales/common.ts
+++ b/apps/frontend/src/i18n/locales/common.ts
@@ -135,6 +135,7 @@ export const common = {
         vdsina: 'VDSina',
         cloudflare: 'Cloudflare',
         stormwall: 'StormWall',
+        doubleservers: 'Double Servers',
         manual: 'Manual',
       },
       rateSource: {
@@ -277,6 +278,7 @@ export const common = {
         vdsina: 'VDSina',
         cloudflare: 'Cloudflare',
         stormwall: 'StormWall',
+        doubleservers: 'Double Servers',
         manual: 'Ручной',
       },
       rateSource: {

--- a/apps/frontend/src/i18n/locales/providers.ts
+++ b/apps/frontend/src/i18n/locales/providers.ts
@@ -100,6 +100,7 @@ export const providers = {
       begetApiPassword: 'API password (optional, for balance)',
       begetApiPasswordDesc:
         'Separate "Beget API" password from the panel (Account → Security → Beget API) — enables balance sync',
+      doubleserversEmailDesc: 'Email used to sign in at doubleservers.com/login',
       porkbunApiKey: 'API key',
       porkbunApiKeyDesc: 'Porkbun → Account → API Access → create an API key',
       porkbunSecretKey: 'Secret API key',
@@ -116,6 +117,7 @@ export const providers = {
       vps4Token: 'Enter the 4VPS API token',
       netcupToken: 'Authorize via netcup or paste a refresh token',
       begetCreds: 'Enter the Beget login and password',
+      doubleserversCreds: 'Enter the Double Servers email and password',
       vultrToken: 'Enter the Vultr API key',
       porkbunCreds: 'Enter the Porkbun API key and secret key',
       linodeToken: 'Enter the Linode API token',
@@ -247,6 +249,7 @@ export const providers = {
       begetApiPassword: 'API-пароль (необязательно, для баланса)',
       begetApiPasswordDesc:
         'Отдельный пароль «Beget API» из панели (Аккаунт → Безопасность → Beget API) — включает синк баланса',
+      doubleserversEmailDesc: 'Email для входа на doubleservers.com/login',
       porkbunApiKey: 'API-ключ',
       porkbunApiKeyDesc: 'Porkbun → Account → API Access → создать API-ключ',
       porkbunSecretKey: 'Секретный API-ключ',
@@ -263,6 +266,7 @@ export const providers = {
       vps4Token: 'Укажите API-токен 4VPS',
       netcupToken: 'Авторизуйтесь через netcup или вставьте refresh-токен',
       begetCreds: 'Укажите логин и пароль Beget',
+      doubleserversCreds: 'Укажите email и пароль Double Servers',
       vultrToken: 'Укажите API-ключ Vultr',
       porkbunCreds: 'Укажите API-ключ и секретный ключ Porkbun',
       linodeToken: 'Укажите API-токен Linode',

--- a/apps/frontend/src/i18n/locales/providers.ts
+++ b/apps/frontend/src/i18n/locales/providers.ts
@@ -63,8 +63,9 @@ export const providers = {
       apiTokenDescLinode:
         'Linode → Account → API Tokens → create a Personal Access Token (read access to Account and Linodes)',
       apiTokenDescAeza: 'Aeza panel → API Keys → create an API key',
-      apiTokenDescTimeweb:
-        'Go to "API and Terraform" → "Add token", enter any name, then "Issue".',
+      apiTokenDescTimeweb: 'Go to "API and Terraform" → "Add token", enter any name, then "Issue".',
+      apiTokenDescHetzner:
+        'Go to console.hetzner.com. Open "Projects" → "Default" → "Security" → "API Tokens" → "Generate API Token", enter any name, then "Generate API Token".',
       apiTokenDescVdsina:
         'VDSina control panel → user list → permanent API token, sent as the Authorization header',
       apiBaseUrlDescVdsina:
@@ -215,6 +216,8 @@ export const providers = {
       apiTokenDescAeza: 'Панель Aeza → API Keys → создать API-ключ',
       apiTokenDescTimeweb:
         'Перейдите в "API и Terraform" → "Добавить токен", введите любое имя, затем "Выпустить".',
+      apiTokenDescHetzner:
+        'Зайдите на console.hetzner.com. Перейдите в "Проекты" → "Default" → "Безопасность" → "API-токены" → "Создать API-токен", введите любое имя, затем "Создать API-токен".',
       apiTokenDescVdsina:
         'Личный кабинет VDSina → список пользователей → постоянный API-токен (заголовок Authorization)',
       apiBaseUrlDescVdsina:

--- a/apps/frontend/src/i18n/locales/providers.ts
+++ b/apps/frontend/src/i18n/locales/providers.ts
@@ -63,6 +63,8 @@ export const providers = {
       apiTokenDescLinode:
         'Linode → Account → API Tokens → create a Personal Access Token (read access to Account and Linodes)',
       apiTokenDescAeza: 'Aeza panel → API Keys → create an API key',
+      apiTokenDescTimeweb:
+        'Go to "API and Terraform" → "Add token", enter any name, then "Issue".',
       apiTokenDescVdsina:
         'VDSina control panel → user list → permanent API token, sent as the Authorization header',
       apiBaseUrlDescVdsina:
@@ -211,6 +213,8 @@ export const providers = {
       apiTokenDescLinode:
         'Linode → Account → API Tokens → создать Personal Access Token (доступ на чтение к Account и Linodes)',
       apiTokenDescAeza: 'Панель Aeza → API Keys → создать API-ключ',
+      apiTokenDescTimeweb:
+        'Перейдите в "API и Terraform" → "Добавить токен", введите любое имя, затем "Выпустить".',
       apiTokenDescVdsina:
         'Личный кабинет VDSina → список пользователей → постоянный API-токен (заголовок Authorization)',
       apiBaseUrlDescVdsina:

--- a/apps/frontend/src/i18n/locales/providers.ts
+++ b/apps/frontend/src/i18n/locales/providers.ts
@@ -103,7 +103,11 @@ export const providers = {
       begetApiPassword: 'API password (optional, for balance)',
       begetApiPasswordDesc:
         'Separate "Beget API" password from the panel (Account → Security → Beget API) — enables balance sync',
-      doubleserversEmailDesc: 'Email used to sign in at doubleservers.com/login',
+      doubleserversSetupStep1: 'Go to doubleservers.com and open the "Profile" section.',
+      doubleserversSetupStep2:
+        'Go to "BACKUP LOGIN VIA EMAIL". Enter the email and password, then click "Attach email". Enter the code sent to your email and click "Confirm". Enter the credentials in the fields below.',
+      doubleserversSetupStep3:
+        'Optional. Go to "Authenticator app" and click "Connect". Enter the key you receive, confirm it in an external authenticator, click "Confirm", then paste the same key into the field below.',
       porkbunApiKey: 'API key',
       porkbunApiKeyDesc: 'Porkbun → Account → API Access → create an API key',
       porkbunSecretKey: 'Secret API key',
@@ -256,7 +260,11 @@ export const providers = {
       begetApiPassword: 'API-пароль (необязательно, для баланса)',
       begetApiPasswordDesc:
         'Отдельный пароль «Beget API» из панели (Аккаунт → Безопасность → Beget API) — включает синк баланса',
-      doubleserversEmailDesc: 'Email для входа на doubleservers.com/login',
+      doubleserversSetupStep1: 'Зайдите на doubleservers.com и откройте раздел "Profile".',
+      doubleserversSetupStep2:
+        'Перейдите к "BACKUP LOGIN VIA EMAIL". Введите email и пароль и нажмите "Attach email". Введите код, отправленный на почту, и нажмите "Confirm". Введите креды в поля ниже.',
+      doubleserversSetupStep3:
+        'Опционально. Перейдите к "Authenticator app" и нажмите "Connect". Введите полученный ключ и подтвердите его через внешний аутентификатор, нажмите "Confirm", а затем продублируйте тот же самый ключ в поле ниже.',
       porkbunApiKey: 'API-ключ',
       porkbunApiKeyDesc: 'Porkbun → Account → API Access → создать API-ключ',
       porkbunSecretKey: 'Секретный API-ключ',

--- a/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
+++ b/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
@@ -12,27 +12,66 @@ import {
   IconRobot,
   IconUser,
 } from '@tabler/icons-react';
-import { Fragment, type ReactNode } from 'react';
-import type { YandexDiscover } from '@infra/shared';
-import type { UseFormReturn } from 'react-hook-form';
+import { Fragment, type ReactNode, useCallback, useRef } from 'react';
+import type { ProviderCredentialsReveal, YandexDiscover } from '@infra/shared';
+import { Controller, type UseFormReturn } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { apiErrorMessage } from '@/api/client';
-import { useYandexDiscover } from '@/api/providers';
+import {
+  revealProviderCredentials,
+  type SecretField,
+  useYandexDiscover,
+} from '@/api/providers';
 import { NetcupAuthorizeButton } from '@/components/NetcupAuthorizeButton';
-import { PasswordInput } from '@/components/PasswordInput';
+import { SecretInput } from '@/components/SecretInput';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
+import type { StoredSecretFlags } from './ProviderFormFields';
 import type { FormValues } from './providerForm';
 
 interface ProviderCredentialFieldsProps {
   form: UseFormReturn<FormValues>;
-  editing: boolean;
-  // Set in the edit modal so Yandex discovery can reuse the stored key without re-pasting it.
   providerUuid?: string;
+  storedSecrets?: StoredSecretFlags;
+}
+
+function SecretFormField({
+  form,
+  name,
+  id,
+  hasStored,
+  reveal,
+  placeholder,
+  multiline,
+}: {
+  form: UseFormReturn<FormValues>;
+  name: SecretField;
+  id: string;
+  hasStored?: boolean;
+  reveal: (field: SecretField) => Promise<string>;
+  placeholder?: string;
+  multiline?: boolean;
+}) {
+  return (
+    <Controller
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <SecretInput
+          id={id}
+          value={field.value}
+          onChange={field.onChange}
+          hasStored={hasStored}
+          onReveal={hasStored ? () => reveal(name) : undefined}
+          placeholder={placeholder}
+          multiline={multiline}
+        />
+      )}
+    />
+  );
 }
 
 /** Field wrapper: label plus an optional description and credential deep link above the input. */
@@ -380,22 +419,29 @@ function isCompleteYandexKey(raw: string): boolean {
   }
 }
 
-// The per-connector credential inputs, switched on the selected kind. Secret inputs use the
-// "keep empty to keep unchanged" placeholder when editing.
 export function ProviderCredentialFields({
   form,
-  editing,
   providerUuid,
+  storedSecrets,
 }: ProviderCredentialFieldsProps) {
   const { t } = useTranslation();
   const kind = form.watch('kind');
-  const keepEmpty = editing ? t('providers.keepEmpty') : '';
-  const keepEmptyOrOptional = editing ? t('providers.keepEmpty') : t('common.optional');
+  const optionalPh = t('common.optional');
+  const revealCache = useRef<{ uuid: string; data: ProviderCredentialsReveal } | null>(null);
+  const reveal = useCallback(
+    async (field: SecretField) => {
+      if (!providerUuid) return '';
+      if (!revealCache.current || revealCache.current.uuid !== providerUuid) {
+        revealCache.current = {
+          uuid: providerUuid,
+          data: await revealProviderCredentials(providerUuid),
+        };
+      }
+      return revealCache.current.data[field] ?? '';
+    },
+    [providerUuid],
+  );
 
-  // Yandex scope badges: the connector auto-resolves the folders it scans for servers and the
-  // billing account it reads, so we just surface them read-only. Resolved from the entered key
-  // (create) or the stored provider (edit, empty field = keep the key unchanged). A keyed query so
-  // the result is cached per input and survives StrictMode's double mount.
   const yandexToken = form.watch('token');
   const yandexBody: YandexDiscover | null =
     kind !== 'yandex'
@@ -426,10 +472,12 @@ export function ProviderCredentialFields({
           <Input id="cred-username" {...form.register('username')} />
         </Field>
         <Field id="cred-password" label={t('providers.field.password')}>
-          <PasswordInput
+          <SecretFormField
+            form={form}
+            name="password"
             id="cred-password"
-            placeholder={keepEmpty}
-            {...form.register('password')}
+            hasStored={storedSecrets?.hasPassword}
+            reveal={reveal}
           />
         </Field>
         <Field
@@ -458,7 +506,13 @@ export function ProviderCredentialFields({
           label={t('providers.field.apiToken')}
           description={t('providers.field.apiTokenDescCloudflare')}
         >
-          <PasswordInput id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+          <SecretFormField
+            form={form}
+            name="token"
+            id="cred-token"
+            hasStored={storedSecrets?.hasToken}
+            reveal={reveal}
+          />
         </Field>
       </>
     );
@@ -480,10 +534,12 @@ export function ProviderCredentialFields({
           <Input id="cred-username" {...form.register('username')} />
         </Field>
         <Field id="cred-password" label={t('providers.field.password')}>
-          <PasswordInput
+          <SecretFormField
+            form={form}
+            name="password"
             id="cred-password"
-            placeholder={keepEmpty}
-            {...form.register('password')}
+            hasStored={storedSecrets?.hasPassword}
+            reveal={reveal}
           />
         </Field>
         {kind === 'billmgr' && (
@@ -492,10 +548,13 @@ export function ProviderCredentialFields({
             label={t('providers.field.totpSecret')}
             description={t('providers.field.totpSecretDesc')}
           >
-            <PasswordInput
+            <SecretFormField
+              form={form}
+              name="totpSecret"
               id="cred-totp"
-              placeholder={keepEmptyOrOptional}
-              {...form.register('totpSecret')}
+              hasStored={storedSecrets?.hasTotpSecret}
+              reveal={reveal}
+              placeholder={storedSecrets?.hasTotpSecret ? undefined : optionalPh}
             />
           </Field>
         )}
@@ -512,7 +571,13 @@ export function ProviderCredentialFields({
           description={t('providers.field.apiTokenDesc4vps')}
           link="https://4vps.su/dashboard/api"
         >
-          <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+          <SecretFormField
+            form={form}
+            name="token"
+            id="cred-token"
+            hasStored={storedSecrets?.hasToken}
+            reveal={reveal}
+          />
         </Field>
         <Field
           id="cred-panel-id"
@@ -536,7 +601,13 @@ export function ProviderCredentialFields({
           label={t('providers.field.refreshToken')}
           description={t('providers.field.refreshTokenDescNetcup')}
         >
-          <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+          <SecretFormField
+            form={form}
+            name="token"
+            id="cred-token"
+            hasStored={storedSecrets?.hasToken}
+            reveal={reveal}
+          />
         </Field>
       </>
     );
@@ -550,7 +621,13 @@ export function ProviderCredentialFields({
         description={t('providers.field.apiTokenDescNetlen')}
         link="https://www.netlen.com.tr/panel/api"
       >
-        <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+        <SecretFormField
+          form={form}
+          name="token"
+          id="cred-token"
+          hasStored={storedSecrets?.hasToken}
+          reveal={reveal}
+        />
       </Field>
     );
   }
@@ -563,7 +640,13 @@ export function ProviderCredentialFields({
         description={t('providers.field.apiTokenDescVultr')}
         link="https://console.vultr.com/user/apiaccess/"
       >
-        <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+        <SecretFormField
+          form={form}
+          name="token"
+          id="cred-token"
+          hasStored={storedSecrets?.hasToken}
+          reveal={reveal}
+        />
       </Field>
     );
   }
@@ -576,7 +659,13 @@ export function ProviderCredentialFields({
         description={t('providers.field.apiTokenDescLinode')}
         link="https://cloud.linode.com/profile/tokens"
       >
-        <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+        <SecretFormField
+          form={form}
+          name="token"
+          id="cred-token"
+          hasStored={storedSecrets?.hasToken}
+          reveal={reveal}
+        />
       </Field>
     );
   }
@@ -589,7 +678,13 @@ export function ProviderCredentialFields({
         description={t('providers.field.apiTokenDescAeza')}
         link="https://my.aeza.net/settings/apikeys"
       >
-        <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+        <SecretFormField
+          form={form}
+          name="token"
+          id="cred-token"
+          hasStored={storedSecrets?.hasToken}
+          reveal={reveal}
+        />
       </Field>
     );
   }
@@ -602,7 +697,13 @@ export function ProviderCredentialFields({
         description={t('providers.field.apiTokenDescStormwall')}
         link="https://users.stormwall.pro/tokens"
       >
-        <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+        <SecretFormField
+          form={form}
+          name="token"
+          id="cred-token"
+          hasStored={storedSecrets?.hasToken}
+          reveal={reveal}
+        />
       </Field>
     );
   }
@@ -616,7 +717,13 @@ export function ProviderCredentialFields({
           description={t('providers.field.apiTokenDescVdsina')}
           link="https://cp.vdsina.ru/user/list"
         >
-          <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+          <SecretFormField
+            form={form}
+            name="token"
+            id="cred-token"
+            hasStored={storedSecrets?.hasToken}
+            reveal={reveal}
+          />
         </Field>
         <Field
           id="cred-base-url"
@@ -644,10 +751,12 @@ export function ProviderCredentialFields({
           <Input id="cred-username" {...form.register('username')} />
         </Field>
         <Field id="cred-password" label={t('providers.field.password')}>
-          <PasswordInput
+          <SecretFormField
+            form={form}
+            name="password"
             id="cred-password"
-            placeholder={keepEmpty}
-            {...form.register('password')}
+            hasStored={storedSecrets?.hasPassword}
+            reveal={reveal}
           />
         </Field>
         <Field
@@ -655,10 +764,13 @@ export function ProviderCredentialFields({
           label={t('providers.field.totpSecret')}
           description={t('providers.field.totpSecretDesc')}
         >
-          <PasswordInput
+          <SecretFormField
+            form={form}
+            name="totpSecret"
             id="cred-totp"
-            placeholder={keepEmptyOrOptional}
-            {...form.register('totpSecret')}
+            hasStored={storedSecrets?.hasTotpSecret}
+            reveal={reveal}
+            placeholder={storedSecrets?.hasTotpSecret ? undefined : optionalPh}
           />
         </Field>
         <Field
@@ -667,10 +779,13 @@ export function ProviderCredentialFields({
           description={t('providers.field.begetApiPasswordDesc')}
           link="https://cp.beget.com/settings/security/api"
         >
-          <PasswordInput
+          <SecretFormField
+            form={form}
+            name="apiPassword"
             id="cred-api-password"
-            placeholder={keepEmptyOrOptional}
-            {...form.register('apiPassword')}
+            hasStored={storedSecrets?.hasApiPassword}
+            reveal={reveal}
+            placeholder={storedSecrets?.hasApiPassword ? undefined : optionalPh}
           />
         </Field>
       </>
@@ -693,10 +808,12 @@ export function ProviderCredentialFields({
           <Input id="cred-username" {...form.register('username')} />
         </Field>
         <Field id="cred-password" label={t('providers.field.password')}>
-          <PasswordInput
+          <SecretFormField
+            form={form}
+            name="password"
             id="cred-password"
-            placeholder={keepEmpty}
-            {...form.register('password')}
+            hasStored={storedSecrets?.hasPassword}
+            reveal={reveal}
           />
         </Field>
         <Field
@@ -708,10 +825,13 @@ export function ProviderCredentialFields({
             </div>
           }
         >
-          <PasswordInput
+          <SecretFormField
+            form={form}
+            name="totpSecret"
             id="cred-totp"
-            placeholder={keepEmptyOrOptional}
-            {...form.register('totpSecret')}
+            hasStored={storedSecrets?.hasTotpSecret}
+            reveal={reveal}
+            placeholder={storedSecrets?.hasTotpSecret ? undefined : optionalPh}
           />
         </Field>
       </>
@@ -727,13 +847,21 @@ export function ProviderCredentialFields({
           description={t('providers.field.porkbunApiKeyDesc')}
           link="https://porkbun.com/account/api"
         >
-          <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+          <SecretFormField
+            form={form}
+            name="token"
+            id="cred-token"
+            hasStored={storedSecrets?.hasToken}
+            reveal={reveal}
+          />
         </Field>
         <Field id="cred-secret-key" label={t('providers.field.porkbunSecretKey')}>
-          <PasswordInput
+          <SecretFormField
+            form={form}
+            name="secretKey"
             id="cred-secret-key"
-            placeholder={keepEmpty}
-            {...form.register('secretKey')}
+            hasStored={storedSecrets?.hasSecretKey}
+            reveal={reveal}
           />
         </Field>
       </>
@@ -758,16 +886,18 @@ export function ProviderCredentialFields({
             </>
           }
         >
-          <Textarea
+          <SecretFormField
+            form={form}
+            name="token"
             id="cred-token"
-            rows={7}
-            className="font-mono text-xs"
+            hasStored={storedSecrets?.hasToken}
+            reveal={reveal}
+            multiline
             placeholder={
-              editing
-                ? t('providers.keepEmpty')
+              storedSecrets?.hasToken
+                ? undefined
                 : '{\n  "id": "...",\n  "service_account_id": "...",\n  "key_algorithm": "...",\n  "public_key": "...",\n  "private_key": "..."\n}'
             }
-            {...form.register('token')}
           />
         </Field>
         <div className="space-y-2">
@@ -845,7 +975,13 @@ export function ProviderCredentialFields({
           </div>
         }
       >
-        <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+        <SecretFormField
+          form={form}
+          name="token"
+          id="cred-token"
+          hasStored={storedSecrets?.hasToken}
+          reveal={reveal}
+        />
       </Field>
     );
   }
@@ -870,7 +1006,13 @@ export function ProviderCredentialFields({
           </div>
         }
       >
-        <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+        <SecretFormField
+          form={form}
+          name="token"
+          id="cred-token"
+          hasStored={storedSecrets?.hasToken}
+          reveal={reveal}
+        />
       </Field>
     );
   }
@@ -879,7 +1021,13 @@ export function ProviderCredentialFields({
 
   return (
     <Field id="cred-token" label={t('providers.field.apiToken')}>
-      <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+      <SecretFormField
+        form={form}
+        name="token"
+        id="cred-token"
+        hasStored={storedSecrets?.hasToken}
+        reveal={reveal}
+      />
     </Field>
   );
 }

--- a/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
+++ b/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
@@ -1,5 +1,6 @@
 import {
   type Icon,
+  IconCircles,
   IconExternalLink,
   IconGridDots,
   IconKey,
@@ -161,6 +162,55 @@ function renderYaStep(text: string): ReactNode {
   }
   if (last < text.length) {
     parts.push(<Fragment key={key++}>{linkifyCenter(text.slice(last))}</Fragment>);
+  }
+  return parts;
+}
+
+// Timeweb Cloud panel labels (RU/EN). Sidebar section vs primary action buttons.
+const TW_SECTION = new Set(['API и Terraform', 'API and Terraform']);
+const TW_PRIMARY = new Set(['Добавить токен', 'Выпустить', 'Add token', 'Issue']);
+const TW_ICON: Record<string, Icon> = {
+  'API и Terraform': IconCircles,
+  'API and Terraform': IconCircles,
+};
+
+function twTokenClass(label: string): string {
+  if (TW_PRIMARY.has(label)) return 'rounded-full bg-[#5c5de0] text-white';
+  if (TW_SECTION.has(label)) return 'rounded-md bg-[#282e38] text-white';
+  return 'rounded-md bg-white/[0.07] text-foreground ring-1 ring-white/10 ring-inset';
+}
+
+function TwToken({ label }: { label: string }) {
+  const LabelIcon = TW_ICON[label];
+  return (
+    <span
+      className={cn(
+        'mx-0.5 inline-flex items-center gap-1 px-1.5 py-0.5 align-middle text-[0.8em] font-medium leading-none whitespace-nowrap',
+        twTokenClass(label),
+      )}
+    >
+      {LabelIcon && <LabelIcon className="size-3 shrink-0" />}
+      {label}
+    </span>
+  );
+}
+
+function renderTwStep(text: string): ReactNode {
+  const parts: ReactNode[] = [];
+  const re = /"([^"]+)"/g;
+  let last = 0;
+  let key = 0;
+  let m: RegExpExecArray | null = re.exec(text);
+  while (m !== null) {
+    if (m.index > last) {
+      parts.push(<Fragment key={key++}>{text.slice(last, m.index)}</Fragment>);
+    }
+    parts.push(<TwToken key={key++} label={m[1]} />);
+    last = m.index + m[0].length;
+    m = re.exec(text);
+  }
+  if (last < text.length) {
+    parts.push(<Fragment key={key++}>{text.slice(last)}</Fragment>);
   }
   return parts;
 }
@@ -622,14 +672,35 @@ export function ProviderCredentialFields({
     );
   }
 
+  if (kind === 'timeweb') {
+    return (
+      <Field
+        id="cred-token"
+        label={t('providers.field.apiToken')}
+        description={
+          <div className="leading-7">
+            <p>{renderTwStep(t('providers.field.apiTokenDescTimeweb'))}</p>
+            <a
+              href="https://timeweb.cloud/my/api-keys"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-0.5 text-brand underline-offset-4 hover:underline"
+            >
+              timeweb.cloud/my/api-keys
+              <IconExternalLink className="size-3" />
+            </a>
+          </div>
+        }
+      >
+        <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+      </Field>
+    );
+  }
+
   if (kind === 'manual') return null;
 
   return (
-    <Field
-      id="cred-token"
-      label={t('providers.field.apiToken')}
-      link={kind === 'timeweb' ? 'https://timeweb.cloud/my/api-keys' : undefined}
-    >
+    <Field id="cred-token" label={t('providers.field.apiToken')}>
       <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
     </Field>
   );

--- a/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
+++ b/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
@@ -1,6 +1,7 @@
 import {
   type Icon,
   IconCircles,
+  IconCrown,
   IconExternalLink,
   IconGridDots,
   IconKey,
@@ -211,6 +212,78 @@ function renderTwStep(text: string): ReactNode {
   }
   if (last < text.length) {
     parts.push(<Fragment key={key++}>{text.slice(last)}</Fragment>);
+  }
+  return parts;
+}
+
+// Hetzner Cloud console labels (EN/RU). Active tabs (red + underline), sidebar rows, primary buttons.
+const HZ_TAB = new Set(['Projects', 'API Tokens', 'Проекты', 'API-токены']);
+const HZ_NAV = new Set(['Default', 'Security', 'Безопасность']);
+const HZ_PRIMARY = new Set(['Generate API Token', 'Создать API-токен']);
+const HZ_ICON: Record<string, Icon> = {
+  Default: IconCrown,
+  Security: IconKey,
+  Безопасность: IconKey,
+};
+
+function linkifyHetzner(text: string): ReactNode {
+  const marker = 'console.hetzner.com';
+  const idx = text.indexOf(marker);
+  if (idx === -1) return text;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <a
+        href="https://console.hetzner.com"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-brand underline underline-offset-4 hover:no-underline"
+      >
+        {marker}
+      </a>
+      {text.slice(idx + marker.length)}
+    </>
+  );
+}
+
+function hzTokenClass(label: string): string {
+  if (HZ_PRIMARY.has(label)) return 'rounded-md bg-[#a01f2a] text-white';
+  if (HZ_TAB.has(label)) return 'rounded-md bg-[#1a1a1a] text-[#ff5a68]';
+  if (HZ_NAV.has(label)) return 'rounded-md bg-[#252525] text-white';
+  return 'rounded-md bg-white/[0.07] text-foreground ring-1 ring-white/10 ring-inset';
+}
+
+function HzToken({ label }: { label: string }) {
+  const LabelIcon = HZ_ICON[label];
+  return (
+    <span
+      className={cn(
+        'mx-0.5 inline-flex items-center gap-1 px-1.5 py-0.5 align-middle text-[0.8em] font-medium leading-none whitespace-nowrap',
+        hzTokenClass(label),
+      )}
+    >
+      {LabelIcon && <LabelIcon className="size-3 shrink-0" />}
+      {label}
+    </span>
+  );
+}
+
+function renderHzStep(text: string): ReactNode {
+  const parts: ReactNode[] = [];
+  const re = /"([^"]+)"/g;
+  let last = 0;
+  let key = 0;
+  let m: RegExpExecArray | null = re.exec(text);
+  while (m !== null) {
+    if (m.index > last) {
+      parts.push(<Fragment key={key++}>{linkifyHetzner(text.slice(last, m.index))}</Fragment>);
+    }
+    parts.push(<HzToken key={key++} label={m[1]} />);
+    last = m.index + m[0].length;
+    m = re.exec(text);
+  }
+  if (last < text.length) {
+    parts.push(<Fragment key={key++}>{linkifyHetzner(text.slice(last))}</Fragment>);
   }
   return parts;
 }
@@ -587,7 +660,7 @@ export function ProviderCredentialFields({
           description={
             <>
               <span className="font-medium">{t('providers.field.yandexKeySetup')}</span>
-              <ol className="mt-1 list-decimal space-y-1.5 pl-4 leading-7">
+              <ol className="mt-1 list-decimal space-y-1.5 pl-4 text-sm leading-7">
                 <li>{renderYaStep(t('providers.field.yandexKeyStep1'))}</li>
                 <li>{renderYaStep(t('providers.field.yandexKeyStep2'))}</li>
                 <li>{renderYaStep(t('providers.field.yandexKeyStep3'))}</li>
@@ -669,6 +742,22 @@ export function ProviderCredentialFields({
           )}
         </div>
       </>
+    );
+  }
+
+  if (kind === 'hetzner') {
+    return (
+      <Field
+        id="cred-token"
+        label={t('providers.field.apiToken')}
+        description={
+          <div className="text-sm leading-7">
+            {renderHzStep(t('providers.field.apiTokenDescHetzner'))}
+          </div>
+        }
+      >
+        <Input id="cred-token" placeholder={keepEmpty} {...form.register('token')} />
+      </Field>
     );
   }
 

--- a/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
+++ b/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
@@ -2,12 +2,15 @@ import {
   type Icon,
   IconCircles,
   IconCrown,
+  IconDeviceMobile,
   IconExternalLink,
   IconGridDots,
   IconKey,
+  IconMail,
   IconPlus,
   IconRefresh,
   IconRobot,
+  IconUser,
 } from '@tabler/icons-react';
 import { Fragment, type ReactNode } from 'react';
 import type { YandexDiscover } from '@infra/shared';
@@ -284,6 +287,84 @@ function renderHzStep(text: string): ReactNode {
   }
   if (last < text.length) {
     parts.push(<Fragment key={key++}>{linkifyHetzner(text.slice(last))}</Fragment>);
+  }
+  return parts;
+}
+
+const DS_NAV = new Set(['Profile', 'Authenticator app']);
+const DS_SECTION = new Set(['BACKUP LOGIN VIA EMAIL']);
+const DS_PRIMARY = new Set(['Attach email', 'Confirm']);
+const DS_OUTLINE = new Set(['Connect']);
+const DS_ICON: Record<string, Icon> = {
+  Profile: IconUser,
+  'BACKUP LOGIN VIA EMAIL': IconMail,
+  'Authenticator app': IconDeviceMobile,
+};
+
+function linkifyDoubleServers(text: string): ReactNode {
+  const marker = 'doubleservers.com';
+  const idx = text.indexOf(marker);
+  if (idx === -1) return text;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <a
+        href="https://doubleservers.com/dashboard/profile"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-brand underline underline-offset-4 hover:no-underline"
+      >
+        {marker}
+      </a>
+      {text.slice(idx + marker.length)}
+    </>
+  );
+}
+
+function dsTokenClass(label: string): string {
+  if (DS_PRIMARY.has(label)) return 'rounded-full bg-white text-black';
+  if (DS_OUTLINE.has(label))
+    return 'rounded-full bg-[#141414] text-[#c8c8c8] ring-1 ring-[#3a3a3a] ring-inset';
+  if (DS_SECTION.has(label))
+    return 'rounded-md bg-[#141414] text-[#c8c8c8] ring-1 ring-[#3a3a3a] ring-inset';
+  if (DS_NAV.has(label))
+    return 'rounded-md bg-[#141414] text-white ring-1 ring-[#3a3a3a] ring-inset';
+  return 'rounded-md bg-white/[0.07] text-foreground ring-1 ring-white/10 ring-inset';
+}
+
+function DsToken({ label }: { label: string }) {
+  const LabelIcon = DS_ICON[label];
+  return (
+    <span
+      className={cn(
+        'mx-0.5 inline-flex items-center gap-1 px-1.5 py-0.5 align-middle text-[0.8em] font-medium leading-none whitespace-nowrap',
+        dsTokenClass(label),
+      )}
+    >
+      {LabelIcon && <LabelIcon className="size-3 shrink-0" />}
+      {label}
+    </span>
+  );
+}
+
+function renderDsStep(text: string): ReactNode {
+  const parts: ReactNode[] = [];
+  const re = /"([^"]+)"/g;
+  let last = 0;
+  let key = 0;
+  let m: RegExpExecArray | null = re.exec(text);
+  while (m !== null) {
+    if (m.index > last) {
+      parts.push(
+        <Fragment key={key++}>{linkifyDoubleServers(text.slice(last, m.index))}</Fragment>,
+      );
+    }
+    parts.push(<DsToken key={key++} label={m[1]} />);
+    last = m.index + m[0].length;
+    m = re.exec(text);
+  }
+  if (last < text.length) {
+    parts.push(<Fragment key={key++}>{linkifyDoubleServers(text.slice(last))}</Fragment>);
   }
   return parts;
 }
@@ -602,10 +683,14 @@ export function ProviderCredentialFields({
         <Field
           id="cred-username"
           label={t('providers.field.loginEmail')}
-          description={t('providers.field.doubleserversEmailDesc')}
-          link="https://doubleservers.com/login"
+          description={
+            <div className="space-y-1.5 text-sm leading-7">
+              <p>{renderDsStep(t('providers.field.doubleserversSetupStep1'))}</p>
+              <p>{renderDsStep(t('providers.field.doubleserversSetupStep2'))}</p>
+            </div>
+          }
         >
-          <Input id="cred-username" type="email" {...form.register('username')} />
+          <Input id="cred-username" {...form.register('username')} />
         </Field>
         <Field id="cred-password" label={t('providers.field.password')}>
           <PasswordInput
@@ -617,7 +702,11 @@ export function ProviderCredentialFields({
         <Field
           id="cred-totp"
           label={t('providers.field.totpSecret')}
-          description={t('providers.field.totpSecretDesc')}
+          description={
+            <div className="text-sm leading-7">
+              {renderDsStep(t('providers.field.doubleserversSetupStep3'))}
+            </div>
+          }
         >
           <PasswordInput
             id="cred-totp"

--- a/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
+++ b/apps/frontend/src/pages/providers/ProviderCredentialFields.tsx
@@ -473,6 +473,39 @@ export function ProviderCredentialFields({
     );
   }
 
+  if (kind === 'doubleservers') {
+    return (
+      <>
+        <Field
+          id="cred-username"
+          label={t('providers.field.loginEmail')}
+          description={t('providers.field.doubleserversEmailDesc')}
+          link="https://doubleservers.com/login"
+        >
+          <Input id="cred-username" type="email" {...form.register('username')} />
+        </Field>
+        <Field id="cred-password" label={t('providers.field.password')}>
+          <PasswordInput
+            id="cred-password"
+            placeholder={keepEmpty}
+            {...form.register('password')}
+          />
+        </Field>
+        <Field
+          id="cred-totp"
+          label={t('providers.field.totpSecret')}
+          description={t('providers.field.totpSecretDesc')}
+        >
+          <PasswordInput
+            id="cred-totp"
+            placeholder={keepEmptyOrOptional}
+            {...form.register('totpSecret')}
+          />
+        </Field>
+      </>
+    );
+  }
+
   if (kind === 'porkbun') {
     return (
       <>

--- a/apps/frontend/src/pages/providers/ProviderDetailModal.tsx
+++ b/apps/frontend/src/pages/providers/ProviderDetailModal.tsx
@@ -93,6 +93,13 @@ export function ProviderDetailModal({
                 editing
                 kindOptions={kindOptions}
                 providerUuid={shown.uuid}
+                storedSecrets={{
+                  hasToken: shown.hasToken,
+                  hasPassword: shown.hasPassword,
+                  hasTotpSecret: shown.hasTotpSecret,
+                  hasApiPassword: shown.hasApiPassword,
+                  hasSecretKey: shown.hasSecretKey,
+                }}
               />
             </form>
 

--- a/apps/frontend/src/pages/providers/ProviderFormFields.tsx
+++ b/apps/frontend/src/pages/providers/ProviderFormFields.tsx
@@ -15,12 +15,21 @@ import {
 import { ProviderCredentialFields } from './ProviderCredentialFields';
 import { DEFAULT_LOGIN_URLS, type FormValues } from './providerForm';
 
+export type StoredSecretFlags = {
+  hasToken?: boolean;
+  hasPassword?: boolean;
+  hasTotpSecret?: boolean;
+  hasApiPassword?: boolean;
+  hasSecretKey?: boolean;
+};
+
 interface ProviderFormFieldsProps {
   form: UseFormReturn<FormValues>;
   editing: boolean;
   kindOptions: { value: string; label: string }[];
   // Passed in edit mode so Yandex discovery can reuse the stored key.
   providerUuid?: string;
+  storedSecrets?: StoredSecretFlags;
 }
 
 // The provider form body, shared by the create modal and the detail modal (editing mode).
@@ -29,6 +38,7 @@ export function ProviderFormFields({
   editing,
   kindOptions,
   providerUuid,
+  storedSecrets,
 }: ProviderFormFieldsProps) {
   const { t } = useTranslation();
   const nameError = form.formState.errors.name;
@@ -132,7 +142,11 @@ export function ProviderFormFields({
       {/* Manual providers have no credentials — skip the empty section shell. */}
       {kind !== 'manual' && (
         <FormSection icon={IconKey} title={t('providers.section.credentials')}>
-          <ProviderCredentialFields form={form} editing={editing} providerUuid={providerUuid} />
+          <ProviderCredentialFields
+            form={form}
+            providerUuid={providerUuid}
+            storedSecrets={storedSecrets}
+          />
         </FormSection>
       )}
     </>

--- a/apps/frontend/src/pages/providers/ProvidersPage.tsx
+++ b/apps/frontend/src/pages/providers/ProvidersPage.tsx
@@ -70,7 +70,7 @@ export function ProvidersPage() {
       name: p.name,
       kind: p.kind,
       loginUrl: p.loginUrl ?? '',
-      // Non-secret fields are prefilled; password/totpSecret stay blank ("keep unchanged").
+      // Non-secret fields are prefilled; secrets stay blank until reveal-on-demand.
       baseUrl: p.baseUrl ?? '',
       username: p.username ?? '',
       accountId: p.accountId ?? '',

--- a/apps/frontend/src/pages/providers/providerForm.ts
+++ b/apps/frontend/src/pages/providers/providerForm.ts
@@ -38,6 +38,7 @@ export const DEFAULT_LOGIN_URLS: Record<string, string> = {
   cloudflare: 'https://dash.cloudflare.com',
   porkbun: 'https://porkbun.com/account',
   yandex: 'https://console.yandex.cloud',
+  doubleservers: 'https://doubleservers.com/dashboard',
 };
 
 export const EMPTY_FORM: FormValues = {
@@ -67,6 +68,8 @@ export function validateProviderCredentials(v: FormValues, t: TFunction): string
   if (v.kind === '4vps' && !v.token) return t('providers.err.vps4Token');
   if (v.kind === 'netcup' && !v.token) return t('providers.err.netcupToken');
   if (v.kind === 'beget' && !(v.username && v.password)) return t('providers.err.begetCreds');
+  if (v.kind === 'doubleservers' && !(v.username && v.password))
+    return t('providers.err.doubleserversCreds');
   if (v.kind === 'vultr' && !v.token) return t('providers.err.vultrToken');
   if (v.kind === 'porkbun' && !(v.token && v.secretKey)) return t('providers.err.porkbunCreds');
   if (v.kind === 'linode' && !v.token) return t('providers.err.linodeToken');

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-/** Connector kinds. API-backed: timeweb, hetzner, netcup, hostbill, billmgr, selectel, 4vps, netlen, beget, porkbun, vultr, linode, aeza, vdsina, cloudflare, stormwall, yandex. manual = no sync. */
+/** Connector kinds. API-backed: timeweb, hetzner, netcup, hostbill, billmgr, selectel, 4vps, netlen, beget, porkbun, vultr, linode, aeza, vdsina, cloudflare, stormwall, yandex, doubleservers. manual = no sync. */
 export const providerKindSchema = z.enum([
   'timeweb',
   'hetzner',
@@ -19,6 +19,7 @@ export const providerKindSchema = z.enum([
   'cloudflare',
   'stormwall',
   'yandex',
+  'doubleservers',
   'manual',
 ]);
 export type ProviderKind = z.infer<typeof providerKindSchema>;

--- a/packages/shared/src/routes.ts
+++ b/packages/shared/src/routes.ts
@@ -48,6 +48,7 @@ export const API_SUB = {
   PROVIDER_SYNC: `${ID}/sync`,
   PROVIDER_SYNC_RUNS: `${ID}/sync-runs`,
   PROVIDER_BALANCE_HISTORY: `${ID}/balance-history`,
+  PROVIDER_CREDENTIALS_REVEAL: `${ID}/credentials/reveal`,
   // netcup OAuth2 device flow (in-panel token acquisition).
   PROVIDER_NETCUP_DEVICE_START: 'netcup/device/start',
   PROVIDER_NETCUP_DEVICE_POLL: 'netcup/device/poll',
@@ -90,6 +91,8 @@ export const API_PATH = {
     SYNC_RUNS: (uuid: string) => pathId(API.PROVIDERS, API_SUB.PROVIDER_SYNC_RUNS, uuid),
     BALANCE_HISTORY: (uuid: string) =>
       pathId(API.PROVIDERS, API_SUB.PROVIDER_BALANCE_HISTORY, uuid),
+    CREDENTIALS_REVEAL: (uuid: string) =>
+      pathId(API.PROVIDERS, API_SUB.PROVIDER_CREDENTIALS_REVEAL, uuid),
     NETCUP_DEVICE_START: path(API.PROVIDERS, API_SUB.PROVIDER_NETCUP_DEVICE_START),
     NETCUP_DEVICE_POLL: path(API.PROVIDERS, API_SUB.PROVIDER_NETCUP_DEVICE_POLL),
     YANDEX_DISCOVER: path(API.PROVIDERS, API_SUB.PROVIDER_YANDEX_DISCOVER),

--- a/packages/shared/src/schemas/provider.ts
+++ b/packages/shared/src/schemas/provider.ts
@@ -35,6 +35,7 @@ export type Provider = z.infer<typeof providerSchema>;
 // takes `totpSecret` (the base32 seed) so the backend can generate one-time codes.
 // Beget uses `username` (account login) + `password` (Cloud API), plus optional `totpSecret`
 // (OTP 2FA) and `apiPassword` (the separate panel API password, enables the balance lookup).
+// Double Servers uses `username` (email) + `password`, plus optional `totpSecret` (OTP 2FA).
 // None are ever echoed back.
 const credentialFields = {
   token: z.string().min(1).describe('API token').optional(),

--- a/packages/shared/src/schemas/provider.ts
+++ b/packages/shared/src/schemas/provider.ts
@@ -19,16 +19,31 @@ export const providerSchema = z.object({
   servicesCount: z.number().int().nonnegative().describe('Number of services').optional(),
   paymentsCount: z.number().int().nonnegative().describe('Number of payments').optional(),
   // Non-secret credential hints (hostbill/billmgr/selectel/4vps) so the edit form can prefill them.
-  // The password, totpSecret and token are NEVER returned.
+  // Plaintext secrets are NEVER returned here — only presence flags for the edit form mask.
   baseUrl: z.string().describe('API base URL').nullable().optional(),
   username: z.string().describe('Account username').nullable().optional(),
   accountId: z.string().describe('Selectel account number').nullable().optional(),
   projectName: z.string().describe('Cloud project name').nullable().optional(),
   panelId: z.string().describe('Billing panel id').nullable().optional(),
+  hasToken: z.boolean().describe('Stored API token / key present').optional(),
+  hasPassword: z.boolean().describe('Stored account password present').optional(),
+  hasTotpSecret: z.boolean().describe('Stored TOTP secret present').optional(),
+  hasApiPassword: z.boolean().describe('Stored API password present').optional(),
+  hasSecretKey: z.boolean().describe('Stored secret API key present').optional(),
   createdAt: isoDateSchema.describe('Creation time'),
   updatedAt: isoDateSchema.describe('Last update time'),
 });
 export type Provider = z.infer<typeof providerSchema>;
+
+/** Plaintext secrets from an explicit reveal. Not included in list/detail responses. */
+export const providerCredentialsRevealSchema = z.object({
+  token: z.string().optional(),
+  password: z.string().optional(),
+  totpSecret: z.string().optional(),
+  apiPassword: z.string().optional(),
+  secretKey: z.string().optional(),
+});
+export type ProviderCredentialsReveal = z.infer<typeof providerCredentialsRevealSchema>;
 
 // Bearer/API-token providers (timeweb, hetzner, vdsina) use `token`. HostBill/BILLmanager use
 // `baseUrl` + `username` (email) + `password`. BILLmanager with OTP 2FA additionally


### PR DESCRIPTION
### Double Servers
- New Double Servers connector (email/password, optional TOTP)
- Sync balance, servers, top-ups, and charges
- Provider form, i18n, and README entry

### Provider setup badges
- Console-style instruction badges for Timeweb, Hetzner, and Double Servers
- Drop type="email" on the Double Servers login field so Safari does not offer to save the site password

### Credential reveal on edit
- List/detail expose only hasToken / hasPassword / … presence flags
- GET /providers/:uuid/credentials/reveal returns plaintext on eye click
- SecretInput: fixed-length mask, auto-hide, no wrap for multiline fields, eye pinned top-right
