### PR TITLE
fix(vultr): normalise account balance sign (prepaid credit stored as negative)

### DIFF
--- a/apps/backend/src/connectors/vultr/vultr.connector.ts
+++ b/apps/backend/src/connectors/vultr/vultr.connector.ts
@@ -22,7 +22,8 @@ const PER_PAGE = 500;
 const MAX_PAGES = 50; // safety cap so a misbehaving cursor contract can't loop forever
 
 // Vultr v2 (https://api.vultr.com/v2): no npm SDK -> thin axios client, Bearer <API key>, money USD.
-// Balance: GET /account (wrapped in `account`, negative = credit). Services: /instances priced via
+// Balance: GET /account (wrapped in `account`, negative = credit -> normalised, see fetchAccount).
+// Services: /instances priced via
 // /plans (`monthly_cost`). Payments: /billing/history rows -> topup/charge. Cursor pagination via
 // `meta.links.next`. Key may be IP-allowlisted (Access Control) -> off-list IP gives 403 (surfaced).
 export class VultrConnector implements Connector {
@@ -50,7 +51,13 @@ export class VultrConnector implements Connector {
 
   async fetchAccount(signal: AbortSignal): Promise<Account> {
     const { data } = await this.http.get<VultrAccountResponse>('/account', { signal });
-    return { balance: new Decimal(data.account?.balance ?? 0), currency: VULTR_CURRENCY };
+    // Prepaid: Vultr reports `balance` from its own ledger (negative = credit held by the customer)
+    // and bills `pending_charges` for the current period out of that credit. Mirror the console's
+    // "Remaining Credit" so stored credit is positive, consistent with the other connectors
+    // (cf. Linode, where the same sign flip is applied).
+    const credit = new Decimal(String(data.account?.balance ?? 0)).neg();
+    const pendingCharges = new Decimal(String(data.account?.pending_charges ?? 0));
+    return { balance: credit.minus(pendingCharges), currency: VULTR_CURRENCY };
   }
 
   async fetchServices(signal: AbortSignal): Promise<ServiceData[]> {


### PR DESCRIPTION
## Problem

`VultrConnector.fetchAccount()` stores Vultr's raw `account.balance`:

```ts
return { balance: new Decimal(data.account?.balance ?? 0), currency: VULTR_CURRENCY };
```

Vultr reports that field from its own ledger's point of view — a customer holding prepaid credit has a **negative** balance. The file's own header comment already says so (`negative = credit`), but the value is stored as-is, so a funded Vultr account shows up in the panel as a negative balance and is read as debt.

The very same semantics are already normalised in the Linode connector:

```ts
// Postpaid: Linode `balance` is owed (negative = credit). Store the net position so credit is
// positive (consistent with prepaid providers) and money owed shows as a negative balance.
return { balance: new Decimal(String(data.balance ?? 0)).neg(), currency: LINODE_CURRENCY };
```

Vultr just misses that flip.

## Fix

Flip the sign and subtract `pending_charges` — a field already declared in `VultrAccountResponse` but never used. Together they reproduce exactly the **Remaining Credit** figure the Vultr customer portal shows:

```
remaining credit = -balance - pending_charges
```

Example — API returns `balance: -50.00`, `pending_charges: 10.00`; the portal displays **$40.00**. Before this change the panel stored **-50.00**, after it stores **40.00**.

## Notes

- `String(...)` wrapping mirrors the Linode/Aeza connectors and keeps float artefacts out of `Decimal`.
- If you would rather keep Vultr strictly symmetrical with Linode and ignore `pending_charges`, dropping the subtraction is a one-line change — happy to amend.
- There are no connector tests in the repo, so none were added. Verified against a live account: the API returned a negative balance, and the computed value matched the portal's Remaining Credit to the cent.
