### PR TITLE
fix(billmgr): pull the panel favicon during sync

### DIFF
--- a/apps/backend/src/connectors/billmgr/billmgr.connector.ts
+++ b/apps/backend/src/connectors/billmgr/billmgr.connector.ts
@@ -350,6 +350,26 @@ export class BillmgrConnector implements Connector {
     );
   }
 
+  /**
+   * The panel favicon sits behind a per-install skin path (/manimg/<skin>/local_<hash>/…) that
+   * domain-based favicon services never find. The public login page names it in
+   * <link rel="shortcut icon">; no session needed.
+   */
+  async fetchFaviconUrl(signal: AbortSignal): Promise<string | null> {
+    const { data } = await this.http.get<unknown>('', { signal });
+    if (typeof data !== 'string') return null;
+    const tag = /<link[^>]*rel=["'][^"']*icon[^"']*["'][^>]*>/i.exec(data.slice(0, 16_384))?.[0];
+    const href = tag ? /href=["']([^"']+)["']/i.exec(tag)?.[1] : undefined;
+    if (!href) return null;
+    try {
+      // The URL persists to the DB and ships in provider API responses — http(s) only.
+      const url = new URL(href, this.http.defaults.baseURL);
+      return /^https?:$/.test(url.protocol) ? url.href : null;
+    } catch {
+      return null;
+    }
+  }
+
   async fetchAccount(signal: AbortSignal): Promise<Account> {
     await this.ensureSession(signal);
     // ensureSession already fetched (and validated) whoami; reuse it instead of a 2nd request.

--- a/apps/backend/src/connectors/connector.interface.ts
+++ b/apps/backend/src/connectors/connector.interface.ts
@@ -44,4 +44,9 @@ export interface Connector {
   fetchServices(signal: AbortSignal): Promise<ServiceData[]>;
   /** Optional payment/expense ledger, for providers that expose one (e.g. BILLmanager). */
   fetchPayments?(signal: AbortSignal): Promise<PaymentData[]>;
+  /**
+   * Optional direct favicon URL, for self-hosted panels whose icon domain-based favicon
+   * services can't discover (e.g. BILLmanager keeps it behind a per-install skin path).
+   */
+  fetchFaviconUrl?(signal: AbortSignal): Promise<string | null>;
 }

--- a/apps/backend/src/repositories/providers/providers.repository.ts
+++ b/apps/backend/src/repositories/providers/providers.repository.ts
@@ -69,6 +69,10 @@ export class ProvidersRepository {
     });
   }
 
+  async updateFaviconLink(uuid: string, url: string): Promise<void> {
+    await this.prisma.provider.update({ where: { uuid }, data: { faviconLink: url } });
+  }
+
   async markSynced(uuid: string): Promise<void> {
     await this.prisma.provider.update({
       where: { uuid },

--- a/apps/backend/src/sync/sync.service.ts
+++ b/apps/backend/src/sync/sync.service.ts
@@ -125,6 +125,21 @@ export class SyncService implements OnModuleInit {
       const token = this.crypto.decrypt(provider.credentialsEnc);
       const connector = this.connectors.create(provider.kind, token);
 
+      // Needs no auth (reads the public login page) and runs before fetchAccount: the icon
+      // resolves even when the credentials are wrong. Non-fatal; null keeps the stored link.
+      if (connector.fetchFaviconUrl) {
+        try {
+          const url = await connector.fetchFaviconUrl(controller.signal);
+          if (url && url !== provider.faviconLink) {
+            await this.providers.updateFaviconLink(uuid, url);
+          }
+        } catch (e) {
+          this.logger.warn(
+            `Favicon fetch for "${provider.name}" (${uuid}) skipped: ${e instanceof Error ? e.message : String(e)}`,
+          );
+        }
+      }
+
       const account = await this.withRetry(
         `fetchAccount "${provider.name}"`,
         controller.signal,

--- a/apps/frontend/src/components/ProviderIcon.tsx
+++ b/apps/frontend/src/components/ProviderIcon.tsx
@@ -1,12 +1,12 @@
 import { createElement, useEffect, useState } from 'react';
 import { DEFAULT_ICON_BG, iconFgForBg, resolveTablerIcon } from '@/components/tablerIconCatalog';
-import { faviconRootFallback } from '@/utils/favicon';
+import { faviconRootFallback, isFaviconServiceUrl } from '@/utils/favicon';
 
 // Neutral initial avatar, swapped for the favicon only once it loads. Google's "no favicon"
-// placeholder is a ~16px globe, so reject anything that small to avoid the blurry globe. When the
-// primary favicon 404s or is too small (some dashboard subdomains have none), fall back to the
-// registrable domain's icon before settling on the initial. A custom Tabler icon + bg overrides
-// the favicon path entirely.
+// placeholder is a ~16px globe: s2 candidates that small are rejected. Direct favicon URLs
+// skip the gate — a panel's own icon may legitimately be 16px (BILLmanager .ico). When the
+// primary favicon 404s or is rejected, fall back to the registrable domain's icon before
+// settling on the initial. A custom Tabler icon + bg overrides the favicon path entirely.
 export function ProviderIcon({
   name,
   src,
@@ -44,8 +44,11 @@ export function ProviderIcon({
       const img = new Image();
       img.onload = () => {
         if (cancelled) return;
-        if (img.naturalWidth > 16) setResolved({ key, src: candidates[i] });
-        else tryAt(i + 1);
+        if (!isFaviconServiceUrl(candidates[i]) || img.naturalWidth > 16) {
+          setResolved({ key, src: candidates[i] });
+        } else {
+          tryAt(i + 1);
+        }
       };
       img.onerror = () => {
         if (!cancelled) tryAt(i + 1);

--- a/apps/frontend/src/utils/favicon.ts
+++ b/apps/frontend/src/utils/favicon.ts
@@ -30,25 +30,37 @@ export function faviconRootFallback(src: string | null): string | null {
   }
 }
 
-/** Resolve a provider's favicon from its login URL (the provider's dashboard link). */
+/** True for s2 URLs — the service answers "no favicon" with a 16px globe callers filter out. */
+export function isFaviconServiceUrl(src: string): boolean {
+  return src.startsWith(S2_PREFIX);
+}
+
+/**
+ * A direct image URL (has a path, e.g. .../logo.png) is used as-is; a bare domain is resolved
+ * to its site favicon (Google s2).
+ */
+function faviconFromLink(link: string): string | null {
+  try {
+    const url = new URL(link.startsWith('http') ? link : `https://${link}`);
+    if (url.pathname && url.pathname !== '/') return url.href;
+    return faviconResolver(link);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * A provider's icon. faviconLink (when the sync resolved one from the panel itself, e.g. a
+ * BILLmanager skin icon) wins over the loginUrl-derived site favicon.
+ */
 export function providerFavicon(p: {
   faviconLink: string | null;
   loginUrl: string | null;
 }): string | null {
-  return faviconResolver(p.faviconLink || p.loginUrl);
+  return p.faviconLink ? faviconFromLink(p.faviconLink) : faviconResolver(p.loginUrl);
 }
 
-/**
- * A project's icon. A direct image URL (has a path, e.g. .../logo.png) is used as-is; a bare domain
- * is resolved to its site favicon (Google s2), like providers.
- */
+/** A project's icon. */
 export function projectFavicon(faviconLink: string | null): string | null {
-  if (!faviconLink) return null;
-  try {
-    const url = new URL(faviconLink.startsWith('http') ? faviconLink : `https://${faviconLink}`);
-    if (url.pathname && url.pathname !== '/') return url.href;
-    return faviconResolver(faviconLink);
-  } catch {
-    return null;
-  }
+  return faviconLink ? faviconFromLink(faviconLink) : null;
 }


### PR DESCRIPTION
The panel keeps it behind a skin path favicon services can't see — read it off the login page.