### PR TITLE
feat(dashboard): clickable providers and services

### DIFF
--- a/apps/backend/src/analytics/analytics.service.ts
+++ b/apps/backend/src/analytics/analytics.service.ts
@@ -248,6 +248,7 @@ export class AnalyticsService {
       overdueBillings.push({
         serviceUuid: s.uuid,
         name: s.name,
+        providerUuid: s.providerUuid,
         providerName: providerName.get(s.providerUuid) ?? '',
         providerKind: provider?.kind ?? 'manual',
         providerLoginUrl: provider?.loginUrl ?? null,

--- a/apps/backend/src/notifications/messages.ts
+++ b/apps/backend/src/notifications/messages.ts
@@ -159,6 +159,7 @@ export function sampleMessages(): string[] {
   const sampleOverdue: OverdueBilling = {
     serviceUuid: '00000000-0000-0000-0000-000000000000',
     name: 'demo-vps',
+    providerUuid: '00000000-0000-0000-0000-000000000000',
     providerName: 'Тестовый провайдер',
     providerKind: 'manual',
     providerLoginUrl: 'https://example.com',

--- a/apps/frontend/src/hooks/useSelectedParam.ts
+++ b/apps/frontend/src/hooks/useSelectedParam.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+/**
+ * Consume /page?selected=<uuid> (dashboard badges deep-link this way): once the
+ * list arrives, open the matching row's detail view and drop the param — a
+ * refresh after closing the modal must not reopen it.
+ */
+export function useSelectedParam<T extends { uuid: string }>(
+  items: T[] | undefined,
+  open: (item: T) => void,
+) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selected = searchParams.get('selected');
+  const openRef = useRef(open);
+  openRef.current = open;
+
+  useEffect(() => {
+    if (!selected || !items) return;
+    const item = items.find((x) => x.uuid === selected);
+    if (item) openRef.current(item);
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('selected');
+        return next;
+      },
+      { replace: true },
+    );
+  }, [selected, items, setSearchParams]);
+}

--- a/apps/frontend/src/pages/dashboard/ByProviderCard.tsx
+++ b/apps/frontend/src/pages/dashboard/ByProviderCard.tsx
@@ -1,7 +1,8 @@
 import type { AnalyticsSummary, Provider } from '@infra/shared';
-import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
+import { IconChevronLeft, IconChevronRight, IconExternalLink } from '@tabler/icons-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
 import { ProviderIcon } from '@/components/ProviderIcon';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -63,32 +64,49 @@ export function ByProviderCard({ providerRows, base, isLoading, providerOf }: By
               </TableRow>
             </TableHeader>
             <TableBody>
-              {rowsPage.map((p) => (
-                <TableRow key={p.providerUuid}>
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      <ProviderIcon
-                        name={p.name}
-                        src={providerFavicon(
-                          providerOf(p.providerUuid) ?? { faviconLink: null, loginUrl: null },
+              {rowsPage.map((p) => {
+                const provider = providerOf(p.providerUuid);
+                return (
+                  <TableRow key={p.providerUuid}>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Link
+                          to={`/providers?selected=${p.providerUuid}`}
+                          className="flex items-center gap-2 hover:underline"
+                        >
+                          <ProviderIcon
+                            name={p.name}
+                            src={providerFavicon(provider ?? { faviconLink: null, loginUrl: null })}
+                            iconName={provider?.iconName}
+                            iconBg={provider?.iconBg}
+                            size={18}
+                          />
+                          <span className="text-sm font-medium">{p.name}</span>
+                        </Link>
+                        {provider?.loginUrl && (
+                          <a
+                            href={provider.loginUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            aria-label={provider.loginUrl}
+                            className="inline-flex shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+                          >
+                            <IconExternalLink className="size-3.5" />
+                          </a>
                         )}
-                        iconName={providerOf(p.providerUuid)?.iconName}
-                        iconBg={providerOf(p.providerUuid)?.iconBg}
-                        size={18}
-                      />
-                      <span className="text-sm font-medium">{p.name}</span>
-                    </div>
-                  </TableCell>
-                  <TableCell className="text-right">{p.servicesCount}</TableCell>
-                  <TableCell className="text-right">{formatMoney(p.monthlyCost, base)}</TableCell>
-                  <TableCell className="text-right font-semibold">
-                    {formatMoney(p.spent, base)}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {formatMoney(p.balance, p.balanceCurrency)}
-                  </TableCell>
-                </TableRow>
-              ))}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">{p.servicesCount}</TableCell>
+                    <TableCell className="text-right">{formatMoney(p.monthlyCost, base)}</TableCell>
+                    <TableCell className="text-right font-semibold">
+                      {formatMoney(p.spent, base)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {formatMoney(p.balance, p.balanceCurrency)}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         ) : (

--- a/apps/frontend/src/pages/dashboard/DashboardAlerts.tsx
+++ b/apps/frontend/src/pages/dashboard/DashboardAlerts.tsx
@@ -36,6 +36,7 @@ function RunwayChargeRows({ rows }: { rows: RunwayRow[] }) {
               <ProviderBadge
                 name={r.providerName}
                 kind={r.providerKind}
+                uuid={r.providerUuid}
                 faviconLink={r.providerFaviconLink}
                 loginUrl={r.providerLoginUrl}
                 iconName={r.providerIconName}
@@ -320,6 +321,7 @@ export function DashboardAlerts({ overdue, upcoming, runway, topUps }: Dashboard
                     <ProviderBadge
                       name={b.providerName}
                       kind={b.providerKind}
+                      uuid={b.providerUuid}
                       faviconLink={b.providerFaviconLink}
                       loginUrl={b.providerLoginUrl}
                       iconName={b.providerIconName}
@@ -327,6 +329,7 @@ export function DashboardAlerts({ overdue, upcoming, runway, topUps }: Dashboard
                     />
                     <ServiceBadge
                       name={b.name}
+                      uuid={b.serviceUuid}
                       type={b.type}
                       countryCode={b.countryCode}
                       marker={b.marker}
@@ -373,6 +376,7 @@ export function DashboardAlerts({ overdue, upcoming, runway, topUps }: Dashboard
                       <ProviderBadge
                         name={u.providerName}
                         kind={u.providerKind || fromCritical?.providerKind}
+                        uuid={u.providerUuid}
                         faviconLink={u.providerFaviconLink ?? fromCritical?.providerFaviconLink}
                         loginUrl={u.providerLoginUrl ?? fromCritical?.providerLoginUrl}
                         iconName={u.providerIconName ?? fromCritical?.providerIconName}
@@ -445,6 +449,7 @@ export function DashboardAlerts({ overdue, upcoming, runway, topUps }: Dashboard
                       <ProviderBadge
                         name={b.providerName}
                         kind={b.providerKind}
+                        uuid={b.providerUuid}
                         faviconLink={b.providerFaviconLink}
                         loginUrl={b.providerLoginUrl}
                         iconName={b.providerIconName}
@@ -452,6 +457,7 @@ export function DashboardAlerts({ overdue, upcoming, runway, topUps }: Dashboard
                       />
                       <ServiceBadge
                         name={b.name}
+                        uuid={b.serviceUuid}
                         type={b.type}
                         countryCode={b.countryCode}
                         marker={b.marker}

--- a/apps/frontend/src/pages/dashboard/UpcomingBillingsCard.tsx
+++ b/apps/frontend/src/pages/dashboard/UpcomingBillingsCard.tsx
@@ -44,6 +44,7 @@ export function UpcomingBillingsCard({ upcoming }: UpcomingBillingsCardProps) {
                   <ProviderBadge
                     name={ub.providerName}
                     kind={ub.providerKind}
+                    uuid={ub.providerUuid}
                     faviconLink={ub.providerFaviconLink}
                     loginUrl={ub.providerLoginUrl}
                     iconName={ub.providerIconName}
@@ -51,6 +52,7 @@ export function UpcomingBillingsCard({ upcoming }: UpcomingBillingsCardProps) {
                   />
                   <ServiceBadge
                     name={ub.name}
+                    uuid={ub.serviceUuid}
                     type={ub.type}
                     countryCode={ub.countryCode}
                     marker={ub.marker}

--- a/apps/frontend/src/pages/dashboard/dashboardAlertUi.tsx
+++ b/apps/frontend/src/pages/dashboard/dashboardAlertUi.tsx
@@ -1,3 +1,4 @@
+import { IconExternalLink } from '@tabler/icons-react';
 import {
   createContext,
   useContext,
@@ -6,6 +7,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
+import { Link } from 'react-router-dom';
 import { ProviderIcon } from '@/components/ProviderIcon';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
@@ -18,6 +20,7 @@ import { createLayoutGate } from './layoutMeasure';
 export function ProviderBadge({
   name,
   kind,
+  uuid,
   faviconLink,
   loginUrl,
   iconName,
@@ -25,32 +28,65 @@ export function ProviderBadge({
 }: {
   name: string;
   kind?: string | null;
+  uuid?: string | null;
   faviconLink?: string | null;
   loginUrl?: string | null;
   iconName?: string | null;
   iconBg?: string | null;
 }) {
   const tint = providerBadgeStyle(kind);
+  const icon = (
+    <ProviderIcon
+      name={name}
+      src={providerFavicon({ faviconLink: faviconLink ?? null, loginUrl: loginUrl ?? null })}
+      iconName={iconName}
+      iconBg={iconBg}
+      size={16}
+    />
+  );
+  const label = (
+    <span className={cn(uuid && 'group-hover/chip:underline')} style={{ color: tint.color }}>
+      {name}
+    </span>
+  );
   return (
     <Badge
       variant="outline"
       className="gap-1.5 border py-0.5 pr-2 pl-1 font-normal shadow-none"
       style={tint}
     >
-      <ProviderIcon
-        name={name}
-        src={providerFavicon({ faviconLink: faviconLink ?? null, loginUrl: loginUrl ?? null })}
-        iconName={iconName}
-        iconBg={iconBg}
-        size={16}
-      />
-      <span style={{ color: tint.color }}>{name}</span>
+      {uuid ? (
+        // Anchors don't nest and the cabinet link below is a real <a>, hence the chip
+        // itself stays plain and in-app navigation hangs off the icon + name.
+        <Link to={`/providers?selected=${uuid}`} className="group/chip flex items-center gap-1.5">
+          {icon}
+          {label}
+        </Link>
+      ) : (
+        <>
+          {icon}
+          {label}
+        </>
+      )}
+      {loginUrl && (
+        <a
+          href={loginUrl}
+          target="_blank"
+          rel="noreferrer"
+          aria-label={loginUrl}
+          className="inline-flex shrink-0 opacity-60 transition-opacity hover:opacity-100"
+          style={{ color: tint.color }}
+        >
+          <IconExternalLink className="size-3" />
+        </a>
+      )}
     </Badge>
   );
 }
 
 export function ServiceBadge({
   name,
+  uuid,
   type,
   countryCode,
   marker,
@@ -58,6 +94,7 @@ export function ServiceBadge({
   vendor,
 }: {
   name: string;
+  uuid?: string | null;
   type?: string | null;
   countryCode?: string | null;
   marker?: string | null;
@@ -67,12 +104,8 @@ export function ServiceBadge({
   const located = Boolean(type && LOCATED_TYPES.has(type));
   const flag = located ? countryFlag(countryCode) : null;
   const tint = located ? countryBadgeStyle(countryCode) : colorBadgeStyle(markerBg);
-  return (
-    <Badge
-      variant="outline"
-      className="items-center gap-1.5 border py-0.5 pr-2 pl-1 font-normal shadow-none leading-none"
-      style={tint}
-    >
+  const content = (
+    <>
       {flag ? (
         <span className="inline-flex size-4 shrink-0 items-center justify-center text-sm leading-none">
           {flag}
@@ -86,9 +119,26 @@ export function ServiceBadge({
           size={16}
         />
       )}
-      <span className="leading-none" style={{ color: tint.color }}>
+      <span
+        className={cn('leading-none', uuid && 'group-hover/chip:underline')}
+        style={{ color: tint.color }}
+      >
         {name}
       </span>
+    </>
+  );
+  const className =
+    'items-center gap-1.5 border py-0.5 pr-2 pl-1 font-normal shadow-none leading-none';
+  if (!uuid) {
+    return (
+      <Badge variant="outline" className={className} style={tint}>
+        {content}
+      </Badge>
+    );
+  }
+  return (
+    <Badge asChild variant="outline" className={cn(className, 'group/chip')} style={tint}>
+      <Link to={`/services?selected=${uuid}`}>{content}</Link>
     </Badge>
   );
 }

--- a/apps/frontend/src/pages/providers/ProvidersPage.tsx
+++ b/apps/frontend/src/pages/providers/ProvidersPage.tsx
@@ -18,6 +18,7 @@ import { PageHeader } from '@/components/PageHeader';
 import { Button } from '@/components/ui/button';
 import { useEnums } from '@/constants';
 import { useDisclosure } from '@/hooks/useDisclosure';
+import { useSelectedParam } from '@/hooks/useSelectedParam';
 import { sortRows, useTableSort } from '@/hooks/useTableSort';
 import { formatDate } from '@/utils/format';
 import { buildRubMap } from '@/utils/money';
@@ -84,6 +85,7 @@ export function ProvidersPage() {
     });
     setDetailUuid(p.uuid);
   };
+  useSelectedParam(providers, openDetail);
 
   const doSync = async (uuid: string) => {
     try {

--- a/apps/frontend/src/pages/services/ServicesPage.tsx
+++ b/apps/frontend/src/pages/services/ServicesPage.tsx
@@ -21,6 +21,7 @@ import { PageHeader } from '@/components/PageHeader';
 import { Button } from '@/components/ui/button';
 import { useEnums } from '@/constants';
 import { useDisclosure } from '@/hooks/useDisclosure';
+import { useSelectedParam } from '@/hooks/useSelectedParam';
 import { sortRows, useTableSort } from '@/hooks/useTableSort';
 import { useCountryOptions } from '@/utils/countries';
 import { trimMoney } from '@/utils/format';
@@ -191,6 +192,7 @@ export function ServicesPage() {
     });
     setDetailUuid(s.uuid);
   };
+  useSelectedParam(services, openDetail);
 
   const submit = form.handleSubmit(async (v) => {
     const meta = clientMetaFromForm(v);

--- a/packages/shared/src/schemas/analytics.ts
+++ b/packages/shared/src/schemas/analytics.ts
@@ -113,6 +113,7 @@ export type BalanceTopUp = z.infer<typeof balanceTopUpSchema>;
 export const overdueBillingSchema = z.object({
   serviceUuid: uuidSchema.describe('Service UUID'),
   name: z.string().describe('Service name'),
+  providerUuid: uuidSchema.describe('Provider UUID'),
   providerName: z.string().describe('Provider name'),
   providerKind: z.string().describe('Provider connector kind'),
   providerLoginUrl: z.string().describe('Provider cabinet link').nullable(),


### PR DESCRIPTION
- provider and service chips in alert cards, upcoming billings and by-provider table link to the entity
- provider chips and by-provider rows now opening a loginUrl in a new tab
- providers/services pages open the detail modal from ?selected=<uuid> and drop the param after use (shared useSelectedParam hook)
- overdue billings carry providerUuid (schema + analytics service)